### PR TITLE
Add scope:always support and branch-guard hook

### DIFF
--- a/plugins/dl/.claude-plugin/plugin.json
+++ b/plugins/dl/.claude-plugin/plugin.json
@@ -8,5 +8,18 @@
   "homepage": "https://github.com/minusblindfold/devloop",
   "repository": "https://github.com/minusblindfold/devloop",
   "license": "MIT",
-  "keywords": ["workflow", "planning", "design", "implementation", "skills"]
+  "keywords": ["workflow", "planning", "design", "implementation", "skills"],
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/check-branch.sh"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/plugins/dl/hooks/check-branch.sh
+++ b/plugins/dl/hooks/check-branch.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Blocks git commit on main/master — enforces feature-branch workflow.
+set -uo pipefail
+
+# Guard: jq required
+command -v jq &>/dev/null || exit 0
+
+# Guard: must be in a git repo
+git rev-parse --git-dir &>/dev/null 2>&1 || exit 0
+
+# Read hook input
+input=$(cat)
+cmd=$(echo "$input" | jq -r '.tool_input.command // empty')
+
+# Only check git commit commands
+[[ "$cmd" =~ git[[:space:]]+commit ]] || exit 0
+
+# Check current branch
+branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+case "$branch" in
+main | master)
+  echo "Blocked: cannot commit directly to $branch. Create a feature/<slug> branch first." >&2
+  exit 2
+  ;;
+esac
+
+exit 0

--- a/plugins/dl/rules/rules.md
+++ b/plugins/dl/rules/rules.md
@@ -35,7 +35,7 @@ Create a `stack.md` to define your project skeleton (language, framework, build 
 | Field | Required | Values | Description |
 |---|---|---|---|
 | `keywords` | Yes | Array of strings | Terms for keyword-based discovery. Skills match task descriptions against these. |
-| `scope` | No | `bootstrap`, `feature`, `all` | When this rule applies. Default: `all`. |
+| `scope` | No | `bootstrap`, `feature`, `all`, `always` | When this rule applies. `always` bypasses keyword matching — use for cross-cutting conventions. Default: `all`. |
 | `extends` | No | `true`, `false` | If true, appends to a higher-precedence version instead of being overridden. Default: `false`. |
 
 `scope` and `extends` are only relevant when using rule packs with layered resolution. For project-level rules, `keywords` is all you need.
@@ -77,5 +77,5 @@ Rules are additive — start with none and layer in structure as needed.
 For organized, reusable rule sets with management tooling, see [devloop-rules](https://github.com/minusblindfold/devloop-rules). Packs live in their own directories (not in `~/.claude/rules/`) and are discovered by `/resolve-rules` via a layers file (`~/.config/devenv/rule-layers`). This means they're only surfaced to skills when relevant — Claude Code doesn't auto-load them into every session.
 
 Packs add two frontmatter fields that don't matter for simple project-level rules:
-- **`scope`** — controls when a rule applies: `bootstrap` (scaffolding only), `feature` (feature work only), or `all` (both — the default). Useful when a pack has rules that only matter during project setup.
+- **`scope`** — controls when a rule applies: `bootstrap` (scaffolding only), `feature` (feature work only), `all` (both — the default), or `always` (included in every skill invocation regardless of keyword matching — use for cross-cutting conventions like git workflow or code style).
 - **`extends`** — when multiple packs define a rule with the same filename, `extends: true` appends to the higher-precedence version instead of being shadowed. This is how a project-level rule can add to an org-level standard.

--- a/plugins/dl/skills/resolve-rules/SKILL.md
+++ b/plugins/dl/skills/resolve-rules/SKILL.md
@@ -58,11 +58,19 @@ Scan each term against resolved docs' `keywords` arrays. Return all matches.
 ### explicit
 Match each title against the H1 heading of resolved docs. Return all matches.
 
+### Always-scoped rules
+
+After mode matching, scan the full resolution map for rules with `scope: always` in their frontmatter. Merge these into the matched set if not already present. This ensures cross-cutting rules (e.g., git conventions, code style) are included regardless of mode or keywords.
+
 ### Scope filtering
 
-If a `scope:<value>` modifier is present in $ARGUMENTS, apply it as a post-filter after mode matching. Keep rules where the frontmatter `scope` field matches the requested value OR equals `all`. Rules with no `scope` field default to `all` and are always included.
+If a `scope:<value>` modifier is present in $ARGUMENTS, apply it as a post-filter after mode matching. Keep rules where:
+- the frontmatter `scope` matches the requested value, OR
+- `scope` equals `all`, OR
+- `scope` equals `always`, OR
+- no `scope` field is present (defaults to `all`)
 
-Example: `mode:all scope:bootstrap` returns rules with `scope: bootstrap`, `scope: all`, or no `scope` field. Rules with `scope: feature` are excluded.
+Rules with `scope: feature` are excluded when `scope:bootstrap` is requested, and vice versa. Rules with `scope: always` are never excluded.
 
 If no `scope` modifier is present, skip this filter — return all mode-matched rules regardless of scope. This preserves backward compatibility.
 


### PR DESCRIPTION
## Summary
- Add `scope: always` to resolve-rules so cross-cutting rules (like git conventions) are included in every skill invocation regardless of keyword matching
- Ship a PreToolUse hook (`check-branch.sh`) that blocks `git commit` on main/master, enforcing the feature-branch workflow as a hard guardrail
- Document the new scope value in `rules.md`

## Test plan
- [ ] Create a rule with `scope: always` and verify it appears in `/dl:implement` output for a non-matching keyword task
- [ ] Verify `git commit` on main is blocked with a clear error message
- [ ] Verify `git commit` on a `feature/*` branch succeeds
- [ ] Verify the hook is a no-op outside git repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)