### PR TITLE
Strengthen .work artifact save instructions in skills

### DIFF
--- a/plugins/dl/skills/bootstrap/SKILL.md
+++ b/plugins/dl/skills/bootstrap/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bootstrap
-description: Scaffold a project from rules. Use when the user wants to start a new project.
+description: Scaffolds a new project from resolved rule docs, generating skeleton code, configuration, and a bootstrap context marker. Use when starting a new project or scaffolding from rules.
 argument-hint: "<project-name> [description]"
 allowed-tools: Read Write Bash
 ---

--- a/plugins/dl/skills/design/SKILL.md
+++ b/plugins/dl/skills/design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: design
-description: Generate a design document from a plan. Use when the user wants to design, architect, or spec out a feature.
+description: Generates design documents with architecture, diagrams, and task specs from a plan. Use when designing, architecting, or speccing out a feature.
 argument-hint: "[plan slug]"
 allowed-tools: Read Write Bash TaskCreate
 ---
@@ -24,7 +24,7 @@ For simple features where no plan exists yet. Treats $ARGUMENTS as the feature d
 
 1. Ask 1–2 focused clarifying questions (scope and any key constraints). Wait for answers.
 2. Create a minimal plan — typically 1–3 tasks — using the format in the `/plan` skill's `## Plan format` section.
-3. Save it to `<work.dir>/plans/YYYY-MM-DD-<slug>.md`. Run `ls` on the file path to verify it exists with the correct naming convention.
+3. **Save the artifact.** Write it to `<work.dir>/plans/YYYY-MM-DD-<slug>.md`. The create mode step below depends on reading this file from disk. Run `ls` on the file path to verify it exists with the correct naming convention.
 4. Confirm the plan with the user ("Here's the plan I'll design from — does this look right?"). Adjust if needed.
 5. Proceed to create mode using the saved plan.
 
@@ -38,7 +38,7 @@ For simple features where no plan exists yet. Treats $ARGUMENTS as the feature d
 4. Write design doc with: Overview, Architecture, Diagrams, Task Specs.
 5. Choose diagrams that best illuminate the plan — see [diagrams.md](diagrams.md). A feature may warrant more than one; omit diagrams for trivial tasks. Save each as a `.mmd` file in `<work.dir>/designs/diagrams/`. List them in the doc; do not embed code inline.
 6. For each plan task write a spec: Goal, Interfaces, Implementation notes, Acceptance criteria, Dependencies. Also note which rules apply by title (e.g., `**Rules:** JPA Entity Rules, Liquibase Migration Rules`). This tells `/implement` which docs to apply via `/resolve-rules` explicit mode.
-7. Save design to `<work.dir>/designs/YYYY-MM-DD-<slug>-design.md`.
+7. **Save the artifact.** Write the design to `<work.dir>/designs/YYYY-MM-DD-<slug>-design.md`. This file is the primary output — `/implement` reads the design file and its diagrams to guide code generation. Displaying the design in chat without saving it breaks the implementation workflow.
 8. Verify: run `ls` on the saved file path to confirm it exists, has the correct directory (`designs/`), and follows the `YYYY-MM-DD-<slug>-design.md` naming convention. If wrong, fix it before continuing.
 9. Ask the user to review. Once confirmed, suggest running `/implement` to begin.
 
@@ -86,6 +86,7 @@ _(include only the diagrams that apply)_
 
 ## Rules
 
+- **Save `.work` artifact files every time this skill runs.** `/implement` reads the design and `.mmd` diagram files to guide code generation — without saved files, the implementation workflow has no spec to follow. A chat-only response with no saved files is a failed run.
 - Never implement.
 - Only reference skills found in `.claude/skills/`.
 - Stay grounded in the plan — do not invent tasks.

--- a/plugins/dl/skills/implement/SKILL.md
+++ b/plugins/dl/skills/implement/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: implement
-description: Implement a task from a plan and design. Use when the user wants to start coding a planned feature or work through tasks one at a time.
+description: Implements tasks from a plan and design, applying rules and saving implementation notes. Use when coding a planned feature or working through tasks one at a time.
 argument-hint: "[plan-slug] [task-number]"
 allowed-tools: Read Write Edit Bash(git:*) TaskCreate TaskList TaskUpdate
 ---
@@ -52,11 +52,11 @@ Follow the matched rule docs when creating or modifying files that fall under th
 - If out-of-scope work was discovered, suggest running `/plan` refine to capture it.
 - Suggest a git commit scoped to this task.
 - Recommend follow-up skills — only skills found in `.claude/skills/`.
-- Save an implementation note — see [implementation-note.md](implementation-note.md). After saving, run `ls` on the file path to verify it exists in the correct directory with the expected naming convention. If wrong, fix it before continuing.
+- **Save the artifact.** Write an implementation note — see [implementation-note.md](implementation-note.md). Implementation notes record deviations, discoveries, and decisions that inform subsequent tasks and plan refinements. Without a saved note, context is lost between tasks and conversations. After saving, run `ls` on the file path to verify it exists in the correct directory with the expected naming convention. If wrong, fix it before continuing.
 
 ## Rules
 
+- **Save a `.work` artifact file (implementation note) every time this skill runs.** Implementation notes capture deviations and discoveries that inform the next task — without them, subsequent `/implement` runs and `/plan` refinements lose critical context. Save the note even if the task is incomplete.
 - Never start without a design file.
 - Never duplicate tasks — match by subject before creating.
 - Implement only the selected task. Note out-of-scope discoveries in the implementation note rather than acting on them.
-- Save the implementation note even if the task is incomplete.

--- a/plugins/dl/skills/plan/SKILL.md
+++ b/plugins/dl/skills/plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plan
-description: Plan a feature as a task list. Use when the user wants to plan, decompose, or organise work.
+description: Plans features as task lists, decomposes work into ordered steps, and saves plan artifacts. Use when planning, decomposing, or organising work into tasks.
 argument-hint: "[feature description]"
 allowed-tools: Read Write Bash TaskCreate
 ---
@@ -24,7 +24,7 @@ If $ARGUMENTS is empty → list `<work.dir>/plans/`. None: ask what to plan. One
    - If bootstrap context was found: skip questions about tech stack, database, and auth approach (these are already decided). Focus on domain entities, business logic, scope boundaries, and constraints.
    - If no bootstrap context: ask as normal, including stack questions if the project's tech isn't clear from CLAUDE.md.
 3. Create tasks with `TaskCreate`. Make them small, meaningful, and ordered by dependency.
-4. Save plan to `<work.dir>/plans/YYYY-MM-DD-<slug>.md`.
+4. **Save the artifact.** Write the plan to `<work.dir>/plans/YYYY-MM-DD-<slug>.md`. This file is the primary output — `/design` and `/implement` depend on reading it from disk. Displaying the plan in chat without saving the file breaks the downstream workflow.
 5. Verify: run `ls` on the saved file path to confirm it exists, has the correct directory (`plans/`), and follows the `YYYY-MM-DD-<slug>.md` naming convention. If wrong, fix it before continuing.
 6. Ask the user to review. Once confirmed, suggest running `/design` to architect the feature.
 
@@ -54,6 +54,7 @@ Tasks should be small and ordered by dependency. Each task includes a one-line "
 
 ## Rules
 
+- **Save a `.work` artifact file every time this skill runs.** Downstream skills (`/design`, `/implement`) read these files to continue the workflow — without a saved file, the pipeline breaks and the user must redo this work. A chat-only response with no saved file is a failed run.
 - Never implement.
 - Only reference skills found in `.claude/skills/`.
 - Right-size tasks — small over large.

--- a/plugins/dl/skills/research/SKILL.md
+++ b/plugins/dl/skills/research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: research
-description: Scan rules and codebase to inform planning and design. Use when starting a new feature or when discoveries surface during implementation.
+description: Scans rules and codebase to produce structured research artifacts that inform planning and design. Use when starting a new feature, when discoveries surface during implementation, or when a project health check is needed.
 argument-hint: "[feature-slug or topic]"
 allowed-tools: Read Bash Glob Grep
 ---
@@ -42,7 +42,7 @@ For each matched rule, extract:
 
 ## Output
 
-Write to `<work.dir>/research/YYYY-MM-DD-<slug>-research.md` (or `health-check.md` for health-check mode). After saving, run `ls` on the file path to verify it exists in the correct directory with the expected naming convention. If wrong, fix it before continuing.
+**Save the artifact.** Write to `<work.dir>/research/YYYY-MM-DD-<slug>-research.md` (or `health-check.md` for health-check mode). This file is the primary output — `/plan` reads research artifacts to inform task decomposition and clarifying questions. Displaying findings in chat without saving the file means the research is lost to downstream skills. After saving, run `ls` on the file path to verify it exists in the correct directory with the expected naming convention. If wrong, fix it before continuing.
 
 ```markdown
 # <Topic> Research
@@ -83,6 +83,7 @@ If appending to an existing file:
 
 ## Rules
 
+- **Save a `.work` artifact file every time this skill runs.** Downstream skills (`/plan`, `/design`) read research files to inform their work — without a saved file, findings are lost between conversations. A chat-only response with no saved file is a failed run.
 - Never implement. This skill produces context, not code.
 - Never overwrite prior research sections on re-entry.
 - Rule discovery must use the resolution algorithm — never hardcode paths.


### PR DESCRIPTION
## Summary
- Adds reasoning-based save rules to all skill SKILL.md files explaining *why* artifacts must be saved (downstream skills depend on reading them from disk)
- Rewrites skill descriptions in third-person with richer keywords for better triggering, per agentskills.io best practices
- Adds bold "Save the artifact" callouts in procedural steps with concrete consequences for skipping

## Test plan
- [x] Run each skill (`/plan`, `/research`, `/design`, `/implement`) and verify `.work` artifact files are saved
- [x] Confirm skill triggering still works correctly with updated descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)