### PR TITLE
Add CLAUDE.md with versioning conventions, bump to 1.2.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "dl",
       "description": "Structured development workflow for Claude Code — research, plan, design, implement",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "source": "./plugins/dl"
     }
   ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,19 @@
+# devloop
+
+Structured development workflow plugin for Claude Code.
+
+## Versioning
+
+This project uses **semver** (`MAJOR.MINOR.PATCH`). When making changes that affect plugin behavior (skills, commands, hooks, rules), bump the version in **both** files before merging:
+
+- `plugins/dl/.claude-plugin/plugin.json`
+- `.claude-plugin/marketplace.json`
+
+Bump rules:
+- **Patch** (1.1.x): bug fixes, typo corrections, doc-only changes
+- **Minor** (1.x.0): new skills/commands, changed skill behavior, new rules
+- **Major** (x.0.0): breaking changes to skill interfaces or plugin structure
+
+## Git
+
+Always work on a feature branch off `main`. Never commit directly to `main`.

--- a/plugins/dl/.claude-plugin/plugin.json
+++ b/plugins/dl/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dl",
   "description": "Structured development workflow for Claude Code — research, plan, design, implement",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": {
     "name": "minusblindfold"
   },


### PR DESCRIPTION
## Summary
- Adds project-level `CLAUDE.md` documenting semver policy (patch/minor/major rules) and the two files that need updating on version bumps
- Documents git branching convention (always use feature branches)
- Bumps version to `1.2.0` for the skill instruction changes merged in #4

## Test plan
- [x] Verify `CLAUDE.md` is loaded into context on new conversations
- [x] Confirm version is consistent across `plugin.json` and `marketplace.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)