### PR TITLE
Gate artifact saves as precondition to skill wrap-up

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "dl",
       "description": "Structured development workflow for Claude Code — research, plan, design, implement",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "source": "./plugins/dl"
     }
   ]

--- a/plugins/dl/.claude-plugin/plugin.json
+++ b/plugins/dl/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dl",
   "description": "Structured development workflow for Claude Code — research, plan, design, implement",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": {
     "name": "minusblindfold"
   },

--- a/plugins/dl/skills/design/SKILL.md
+++ b/plugins/dl/skills/design/SKILL.md
@@ -7,6 +7,10 @@ allowed-tools: Read Write Bash TaskCreate
 
 Create or refine a feature design.
 
+## Artifact — required output
+
+This skill produces files in `<work.dir>/designs/` (and `<work.dir>/plans/` in bootstrap mode). Every execution — create, bootstrap, or refine — must end with saved artifacts on disk. The review phase below is gated on this: do not present the design to the user or suggest next steps until all artifact files have been written and verified with `ls`.
+
 ## Config
 
 Read `devenv.json` from `${CLAUDE_PLUGIN_ROOT}/devenv.json` (if running as a plugin) or `~/.claude/devenv.json` (fallback). Keys: `work.dir` (default `.work`), `backups.maxPerArtifact` (default 5, applies to refine mode only).
@@ -24,7 +28,7 @@ For simple features where no plan exists yet. Treats $ARGUMENTS as the feature d
 
 1. Ask 1–2 focused clarifying questions (scope and any key constraints). Wait for answers.
 2. Create a minimal plan — typically 1–3 tasks — using the format in the `/plan` skill's `## Plan format` section.
-3. **Save the artifact.** Write it to `<work.dir>/plans/YYYY-MM-DD-<slug>.md`. The create mode step below depends on reading this file from disk. Run `ls` on the file path to verify it exists with the correct naming convention.
+3. Write the plan to `<work.dir>/plans/YYYY-MM-DD-<slug>.md`. **Gate:** run `ls` on the file path — do not proceed to create mode until the file is confirmed on disk.
 4. Confirm the plan with the user ("Here's the plan I'll design from — does this look right?"). Adjust if needed.
 5. Proceed to create mode using the saved plan.
 
@@ -38,8 +42,8 @@ For simple features where no plan exists yet. Treats $ARGUMENTS as the feature d
 4. Write design doc with: Overview, Architecture, Diagrams, Task Specs.
 5. Choose diagrams that best illuminate the plan — see [diagrams.md](diagrams.md). A feature may warrant more than one; omit diagrams for trivial tasks. Save each as a `.mmd` file in `<work.dir>/designs/diagrams/`. List them in the doc; do not embed code inline.
 6. For each plan task write a spec: Goal, Interfaces, Implementation notes, Acceptance criteria, Dependencies. Also note which rules apply by title (e.g., `**Rules:** JPA Entity Rules, Liquibase Migration Rules`). This tells `/implement` which docs to apply via `/resolve-rules` explicit mode.
-7. **Save the artifact.** Write the design to `<work.dir>/designs/YYYY-MM-DD-<slug>-design.md`. This file is the primary output — `/implement` reads the design file and its diagrams to guide code generation. Displaying the design in chat without saving it breaks the implementation workflow.
-8. Verify: run `ls` on the saved file path to confirm it exists, has the correct directory (`designs/`), and follows the `YYYY-MM-DD-<slug>-design.md` naming convention. If wrong, fix it before continuing.
+7. Write the design to `<work.dir>/designs/YYYY-MM-DD-<slug>-design.md`.
+8. **Gate:** run `ls` on the design file and each `.mmd` file. If any are missing, write them now. Do not proceed until all files are confirmed on disk.
 9. Ask the user to review. Once confirmed, suggest running `/implement` to begin.
 
 ## Refine mode
@@ -86,7 +90,6 @@ _(include only the diagrams that apply)_
 
 ## Rules
 
-- **Save `.work` artifact files every time this skill runs.** `/implement` reads the design and `.mmd` diagram files to guide code generation — without saved files, the implementation workflow has no spec to follow. A chat-only response with no saved files is a failed run.
 - Never implement.
 - Only reference skills found in `.claude/skills/`.
 - Stay grounded in the plan — do not invent tasks.

--- a/plugins/dl/skills/implement/SKILL.md
+++ b/plugins/dl/skills/implement/SKILL.md
@@ -7,6 +7,10 @@ allowed-tools: Read Write Edit Bash(git:*) TaskCreate TaskList TaskUpdate
 
 Implement one task from a plan+design pair.
 
+## Artifact — required output
+
+This skill produces an implementation note in `<work.dir>/implementations/`. Every execution — even if the task is incomplete — must end with a saved artifact on disk. The wrap-up phase below is gated on this: do not summarise changes, suggest commits, or recommend next steps until the implementation note has been written and verified with `ls`.
+
 ## Config
 
 Read `devenv.json` from `${CLAUDE_PLUGIN_ROOT}/devenv.json` (if running as a plugin) or `~/.claude/devenv.json` (fallback). Key: `work.dir` (default `.work`).
@@ -47,16 +51,16 @@ Follow the matched rule docs when creating or modifying files that fall under th
 
 ## Wrap up
 
-- Summarise changes (files created/modified).
-- Note any deviations from the design spec — interfaces, structures, or approaches that changed. If significant, suggest running `/design` refine before the next task.
-- If out-of-scope work was discovered, suggest running `/plan` refine to capture it.
-- Suggest a git commit scoped to this task.
-- Recommend follow-up skills — only skills found in `.claude/skills/`.
-- **Save the artifact.** Write an implementation note — see [implementation-note.md](implementation-note.md). Implementation notes record deviations, discoveries, and decisions that inform subsequent tasks and plan refinements. Without a saved note, context is lost between tasks and conversations. After saving, run `ls` on the file path to verify it exists in the correct directory with the expected naming convention. If wrong, fix it before continuing.
+1. Write an implementation note — see [implementation-note.md](implementation-note.md).
+2. **Gate:** run `ls` on the saved file path. If the file does not exist, go back to step 1. Do not proceed until the file is confirmed on disk.
+3. Summarise changes (files created/modified).
+4. Note any deviations from the design spec — interfaces, structures, or approaches that changed. If significant, suggest running `/design` refine before the next task.
+5. If out-of-scope work was discovered, suggest running `/plan` refine to capture it.
+6. Suggest a git commit scoped to this task.
+7. Recommend follow-up skills — only skills found in `.claude/skills/`.
 
 ## Rules
 
-- **Save a `.work` artifact file (implementation note) every time this skill runs.** Implementation notes capture deviations and discoveries that inform the next task — without them, subsequent `/implement` runs and `/plan` refinements lose critical context. Save the note even if the task is incomplete.
 - Never start without a design file.
 - Never duplicate tasks — match by subject before creating.
 - Implement only the selected task. Note out-of-scope discoveries in the implementation note rather than acting on them.

--- a/plugins/dl/skills/plan/SKILL.md
+++ b/plugins/dl/skills/plan/SKILL.md
@@ -7,6 +7,10 @@ allowed-tools: Read Write Bash TaskCreate
 
 Create or refine a feature plan.
 
+## Artifact — required output
+
+This skill produces a file in `<work.dir>/plans/`. Every execution — create or refine — must end with a saved artifact on disk. The wrap-up phase below is gated on this: do not present results to the user or suggest next steps until the artifact file has been written and verified with `ls`.
+
 ## Config
 
 Read `devenv.json` from `${CLAUDE_PLUGIN_ROOT}/devenv.json` (if running as a plugin) or `~/.claude/devenv.json` (fallback). Keys: `work.dir` (default `.work`), `backups.maxPerArtifact` (default 5, applies to refine mode only).
@@ -24,8 +28,8 @@ If $ARGUMENTS is empty → list `<work.dir>/plans/`. None: ask what to plan. One
    - If bootstrap context was found: skip questions about tech stack, database, and auth approach (these are already decided). Focus on domain entities, business logic, scope boundaries, and constraints.
    - If no bootstrap context: ask as normal, including stack questions if the project's tech isn't clear from CLAUDE.md.
 3. Create tasks with `TaskCreate`. Make them small, meaningful, and ordered by dependency.
-4. **Save the artifact.** Write the plan to `<work.dir>/plans/YYYY-MM-DD-<slug>.md`. This file is the primary output — `/design` and `/implement` depend on reading it from disk. Displaying the plan in chat without saving the file breaks the downstream workflow.
-5. Verify: run `ls` on the saved file path to confirm it exists, has the correct directory (`plans/`), and follows the `YYYY-MM-DD-<slug>.md` naming convention. If wrong, fix it before continuing.
+4. Write the plan to `<work.dir>/plans/YYYY-MM-DD-<slug>.md`.
+5. **Gate:** run `ls` on the saved file path. If the file does not exist, go back to step 4. Do not proceed until the file is confirmed on disk.
 6. Ask the user to review. Once confirmed, suggest running `/design` to architect the feature.
 
 ## Refine mode
@@ -54,7 +58,6 @@ Tasks should be small and ordered by dependency. Each task includes a one-line "
 
 ## Rules
 
-- **Save a `.work` artifact file every time this skill runs.** Downstream skills (`/design`, `/implement`) read these files to continue the workflow — without a saved file, the pipeline breaks and the user must redo this work. A chat-only response with no saved file is a failed run.
 - Never implement.
 - Only reference skills found in `.claude/skills/`.
 - Right-size tasks — small over large.

--- a/plugins/dl/skills/research/SKILL.md
+++ b/plugins/dl/skills/research/SKILL.md
@@ -7,6 +7,10 @@ allowed-tools: Read Bash Glob Grep
 
 Scan rules and codebase to produce structured context for the plan/design/implement cycle.
 
+## Artifact — required output
+
+This skill produces a file in `<work.dir>/research/`. Every execution — create, re-entry, or health-check — must end with a saved artifact on disk. The wrap-up phase below is gated on this: do not summarise findings or suggest next steps until the artifact file has been written and verified with `ls`.
+
 ## Config
 
 Read `devenv.json` from `${CLAUDE_PLUGIN_ROOT}/devenv.json` (if running as a plugin) or `~/.claude/devenv.json` (fallback). Keys: `work.dir` (default `.work`).
@@ -42,7 +46,9 @@ For each matched rule, extract:
 
 ## Output
 
-**Save the artifact.** Write to `<work.dir>/research/YYYY-MM-DD-<slug>-research.md` (or `health-check.md` for health-check mode). This file is the primary output — `/plan` reads research artifacts to inform task decomposition and clarifying questions. Displaying findings in chat without saving the file means the research is lost to downstream skills. After saving, run `ls` on the file path to verify it exists in the correct directory with the expected naming convention. If wrong, fix it before continuing.
+Write to `<work.dir>/research/YYYY-MM-DD-<slug>-research.md` (or `health-check.md` for health-check mode).
+
+**Gate:** run `ls` on the saved file path. If the file does not exist, write it now. Do not proceed to the wrap-up phase until the file is confirmed on disk.
 
 ```markdown
 # <Topic> Research
@@ -83,7 +89,6 @@ If appending to an existing file:
 
 ## Rules
 
-- **Save a `.work` artifact file every time this skill runs.** Downstream skills (`/plan`, `/design`) read research files to inform their work — without a saved file, findings are lost between conversations. A chat-only response with no saved file is a failed run.
 - Never implement. This skill produces context, not code.
 - Never overwrite prior research sections on re-entry.
 - Rule discovery must use the resolution algorithm — never hardcode paths.


### PR DESCRIPTION
## Summary
- Adds `## Artifact — required output` section at the top of each skill (plan, research, design, implement) — the first thing read after activation
- Replaces buried "save the file" steps with inline **Gate** checkpoints: `ls` must confirm the file exists on disk before the skill can proceed to wrap-up/review
- For implement, the implementation note is now step 1 of wrap-up, gated before any summary or commit suggestion
- Removes duplicate save reminders from Rules sections to reduce noise
- Bumps to 1.3.0