### PR TITLE
Remove configurable work directory and devenv.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,17 +102,6 @@ Artifacts follow the naming convention `YYYY-MM-DD-<slug>-<type>.md` (e.g., `202
 
 Add `.work/` to your `.gitignore`.
 
-## Config
-
-`devenv.json` in the plugin root controls skill behavior:
-
-```json
-{
-  "backups": { "maxPerArtifact": 5 },
-  "work": { "dir": ".work" }
-}
-```
-
 ## Terminal companion tools
 
 For terminal-based artifact browsing (`view-plan`, `view-design`, `view-research`, `view-implement`, `open-diagrams`, `claude-context`), see [devenv](https://github.com/minusblindfold/devenv). These are optional CLI tools that complement the plugin.

--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -74,7 +74,7 @@ When you refine a plan or design (`/dl:plan refine`, `/dl:design refine`), the p
 └── 2026-03-11-14-30-00-user-auth.md    # timestamped backup
 ```
 
-Backups are named `YYYY-MM-DD-HH-MM-SS-<original-filename>`. A maximum of 5 backups are kept per artifact (configurable via `devenv.json`). Oldest backups are removed when the limit is reached.
+Backups are named `YYYY-MM-DD-HH-MM-SS-<original-filename>`. A maximum of 5 backups are kept per artifact. Oldest backups are removed when the limit is reached.
 
 ## Gitignore
 

--- a/plugins/dl/commands/document.md
+++ b/plugins/dl/commands/document.md
@@ -6,7 +6,6 @@ Review the changes made in this session and update all documentation to match.
 - `plugins/dl/skills/backup.md` → referenced by plan and design skills
 - `plugins/dl/commands/document.md` → Commands section in `README.md`
 - `plugins/dl/rules/rules.md` → Rules section in `README.md`
-- `plugins/dl/devenv.json` → Config section in `README.md`
 - `.claude-plugin/plugin.json` → version, description in `README.md`
 
 ## Doc sync targets
@@ -20,5 +19,4 @@ These docs describe the same system from different angles and must stay consiste
 - New skill → add to skills table in `README.md`, update plugin.json keywords if relevant
 - Skill renamed or removed → update `README.md` skills table
 - New command → add to commands section in `README.md`
-- Config change in `devenv.json` → update config section in `README.md`
 - Version bump → update in `plugin.json` and `marketplace.json`

--- a/plugins/dl/devenv.json
+++ b/plugins/dl/devenv.json
@@ -1,8 +1,0 @@
-{
-  "backups": {
-    "maxPerArtifact": 5
-  },
-  "work": {
-    "dir": ".work"
-  }
-}

--- a/plugins/dl/skills/backup.md
+++ b/plugins/dl/skills/backup.md
@@ -7,4 +7,4 @@ Used by skills that back up artifacts before overwriting them in refine mode.
 1. Resolve the backup directory: `<artifact-dir>/.backup/`.
 2. Copy the current file there as `YYYY-MM-DD-HH-MM-SS-<original-filename>`.
 3. List all backups for this artifact (files matching `*-<original-filename>`), sorted oldest-first.
-4. Delete the oldest until the count is at or below `backups.maxPerArtifact`.
+4. Delete the oldest until the count is at or below 5.

--- a/plugins/dl/skills/bootstrap/SKILL.md
+++ b/plugins/dl/skills/bootstrap/SKILL.md
@@ -9,7 +9,7 @@ Scaffold a new project driven entirely by resolved rule docs.
 
 ## Config
 
-Read `devenv.json` from `${CLAUDE_PLUGIN_ROOT}/devenv.json` (if running as a plugin) or `~/.claude/devenv.json` (fallback). Key: `work.dir` (default `.work`).
+All artifacts are stored under `.work/` in the current project directory.
 
 ## Resolve rules
 
@@ -59,7 +59,7 @@ Generate a `CLAUDE.md` tailored to the project. Derive everything from what was 
 
 ## Write bootstrap context marker
 
-Create `<work.dir>/bootstrap.md` in the project directory. Assemble it dynamically from what was resolved and generated:
+Create `.work/bootstrap.md` in the project directory. Assemble it dynamically from what was resolved and generated:
 
 ```markdown
 # Bootstrap Context
@@ -96,6 +96,6 @@ This marker is read by `/plan` and `/design` to skip redundant questions about e
 - Never generate features beyond the minimal scaffold — that's what `/plan` → `/design` → `/implement` is for.
 - Follow rule docs exactly. If a pattern isn't covered by a rule doc, keep it simple and consistent with the rules that do exist.
 - No hardcoded version numbers in generated code. Use latest stable versions at generation time.
-- The bootstrap context marker goes in the project's `<work.dir>/`, not in devenv.
+- The bootstrap context marker goes in the project's `.work/`, not in devenv.
 - Never hardcode technology choices in this skill. Every file generated must trace back to a resolved rule.
 - If no rules are resolved, do not guess a stack. Stop and tell the user.

--- a/plugins/dl/skills/design/SKILL.md
+++ b/plugins/dl/skills/design/SKILL.md
@@ -9,18 +9,18 @@ Create or refine a feature design.
 
 ## Artifact — required output
 
-This skill produces files in `<work.dir>/designs/` (and `<work.dir>/plans/` in bootstrap mode). Every execution — create, bootstrap, or refine — must end with saved artifacts on disk. The review phase below is gated on this: do not present the design to the user or suggest next steps until all artifact files have been written and verified with `ls`.
+This skill produces files in `.work/designs/` (and `.work/plans/` in bootstrap mode). Every execution — create, bootstrap, or refine — must end with saved artifacts on disk. The review phase below is gated on this: do not present the design to the user or suggest next steps until all artifact files have been written and verified with `ls`.
 
 ## Config
 
-Read `devenv.json` from `${CLAUDE_PLUGIN_ROOT}/devenv.json` (if running as a plugin) or `~/.claude/devenv.json` (fallback). Keys: `work.dir` (default `.work`), `backups.maxPerArtifact` (default 5, applies to refine mode only).
+All artifacts are stored under `.work/` in the current project directory.
 
 ## Mode
 
-If $ARGUMENTS is set → check `<work.dir>/designs/` for `*<arg>*-design.md` (refine) or `<work.dir>/plans/` by exact filename or unambiguous prefix (create). If ambiguous in either case, list matches and ask. No match → bootstrap mode.
+If $ARGUMENTS is set → check `.work/designs/` for `*<arg>*-design.md` (refine) or `.work/plans/` by exact filename or unambiguous prefix (create). If ambiguous in either case, list matches and ask. No match → bootstrap mode.
 If $ARGUMENTS is empty → list designs. None: fall through to plan picker. One: offer refine or new. Many: numbered list.
 
-Plan picker: list `<work.dir>/plans/`. None → ask "What would you like to design?" and enter bootstrap mode. One → auto-select. Many → ask.
+Plan picker: list `.work/plans/`. None → ask "What would you like to design?" and enter bootstrap mode. One → auto-select. Many → ask.
 
 ## Bootstrap mode
 
@@ -28,21 +28,21 @@ For simple features where no plan exists yet. Treats $ARGUMENTS as the feature d
 
 1. Ask 1–2 focused clarifying questions (scope and any key constraints). Wait for answers.
 2. Create a minimal plan — typically 1–3 tasks — using the format in the `/plan` skill's `## Plan format` section.
-3. Write the plan to `<work.dir>/plans/YYYY-MM-DD-<slug>.md`. **Gate:** run `ls` on the file path — do not proceed to create mode until the file is confirmed on disk.
+3. Write the plan to `.work/plans/YYYY-MM-DD-<slug>.md`. **Gate:** run `ls` on the file path — do not proceed to create mode until the file is confirmed on disk.
 4. Confirm the plan with the user ("Here's the plan I'll design from — does this look right?"). Adjust if needed.
 5. Proceed to create mode using the saved plan.
 
 ## Create mode
 
 1. Read plan: extract name, tasks, dependencies.
-2. Explore codebase: read `CLAUDE.md`, scan directory, check `.claude/skills/`. Check for `<work.dir>/bootstrap.md` — if found, read it. The architecture section should reference the bootstrapped stack as established rather than proposing it.
+2. Explore codebase: read `CLAUDE.md`, scan directory, check `.claude/skills/`. Check for `.work/bootstrap.md` — if found, read it. The architecture section should reference the bootstrapped stack as established rather than proposing it.
 3. Ask 2–3 questions. Wait for confirmation.
    - If bootstrap context was found: skip architecture-style questions (already decided). Focus on design-specific questions — data relationships, UI flow, edge cases.
    - If no bootstrap context: ask as normal, including architecture style if unclear.
 4. Write design doc with: Overview, Architecture, Diagrams, Task Specs.
-5. Choose diagrams that best illuminate the plan — see [diagrams.md](diagrams.md). A feature may warrant more than one; omit diagrams for trivial tasks. Save each as a `.mmd` file in `<work.dir>/designs/diagrams/`. List them in the doc; do not embed code inline.
+5. Choose diagrams that best illuminate the plan — see [diagrams.md](diagrams.md). A feature may warrant more than one; omit diagrams for trivial tasks. Save each as a `.mmd` file in `.work/designs/diagrams/`. List them in the doc; do not embed code inline.
 6. For each plan task write a spec: Goal, Interfaces, Implementation notes, Acceptance criteria, Dependencies. Also note which rules apply by title (e.g., `**Rules:** JPA Entity Rules, Liquibase Migration Rules`). This tells `/implement` which docs to apply via `/resolve-rules` explicit mode.
-7. Write the design to `<work.dir>/designs/YYYY-MM-DD-<slug>-design.md`.
+7. Write the design to `.work/designs/YYYY-MM-DD-<slug>-design.md`.
 8. **Gate:** run `ls` on the design file and each `.mmd` file. If any are missing, write them now. Do not proceed until all files are confirmed on disk.
 9. Ask the user to review. Once confirmed, suggest running `/implement` to begin.
 

--- a/plugins/dl/skills/implement/SKILL.md
+++ b/plugins/dl/skills/implement/SKILL.md
@@ -9,21 +9,21 @@ Implement one task from a plan+design pair.
 
 ## Artifact — required output
 
-This skill produces an implementation note in `<work.dir>/implementations/`. Every execution — even if the task is incomplete — must end with a saved artifact on disk. The wrap-up phase below is gated on this: do not summarise changes, suggest commits, or recommend next steps until the implementation note has been written and verified with `ls`.
+This skill produces an implementation note in `.work/implementations/`. Every execution — even if the task is incomplete — must end with a saved artifact on disk. The wrap-up phase below is gated on this: do not summarise changes, suggest commits, or recommend next steps until the implementation note has been written and verified with `ls`.
 
 ## Config
 
-Read `devenv.json` from `${CLAUDE_PLUGIN_ROOT}/devenv.json` (if running as a plugin) or `~/.claude/devenv.json` (fallback). Key: `work.dir` (default `.work`).
+All artifacts are stored under `.work/` in the current project directory.
 
 ## Find the feature
 
-If $ARGUMENTS: treat as `<slug>` or `<slug> <task-N>`. Find plan in `<work.dir>/plans/`, then matching design in `<work.dir>/designs/`. Missing design → "No design found for '<slug>'. Run /design first." and stop.
+If $ARGUMENTS: treat as `<slug>` or `<slug> <task-N>`. Find plan in `.work/plans/`, then matching design in `.work/designs/`. Missing design → "No design found for '<slug>'. Run /design first." and stop.
 If no argument: list plans and designs, match by slug. No pairs → "Run /plan then /design first." and stop. One pair → show it and ask to confirm or describe a new feature. Many → numbered list, ask to pick.
 
 ## Load and sync
 
 1. Read both files in full.
-2. Read any `.mmd` diagrams referenced in the design from `<work.dir>/designs/diagrams/`. Use them to understand the proposed architecture and flow before implementing.
+2. Read any `.mmd` diagrams referenced in the design from `.work/designs/diagrams/`. Use them to understand the proposed architecture and flow before implementing.
 3. Check `.claude/skills/` for available skills. Print what's found.
 4. Sync plan tasks to Claude Code task list: call `TaskList`, then `TaskCreate` for any task not already present.
 5. Print task list with completion status.

--- a/plugins/dl/skills/implement/implementation-note.md
+++ b/plugins/dl/skills/implement/implementation-note.md
@@ -1,6 +1,6 @@
 # Implementation note format
 
-Saved to `<work.dir>/implementations/YYYY-MM-DD-<slug>-task-N.md` after each task, even if incomplete.
+Saved to `.work/implementations/YYYY-MM-DD-<slug>-task-N.md` after each task, even if incomplete.
 
 ```markdown
 # Implementation note: <task subject>

--- a/plugins/dl/skills/plan/SKILL.md
+++ b/plugins/dl/skills/plan/SKILL.md
@@ -9,33 +9,33 @@ Create or refine a feature plan.
 
 ## Artifact — required output
 
-This skill produces a file in `<work.dir>/plans/`. Every execution — create or refine — must end with a saved artifact on disk. The wrap-up phase below is gated on this: do not present results to the user or suggest next steps until the artifact file has been written and verified with `ls`.
+This skill produces a file in `.work/plans/`. Every execution — create or refine — must end with a saved artifact on disk. The wrap-up phase below is gated on this: do not present results to the user or suggest next steps until the artifact file has been written and verified with `ls`.
 
 ## Config
 
-Read `devenv.json` from `${CLAUDE_PLUGIN_ROOT}/devenv.json` (if running as a plugin) or `~/.claude/devenv.json` (fallback). Keys: `work.dir` (default `.work`), `backups.maxPerArtifact` (default 5, applies to refine mode only).
+All artifacts are stored under `.work/` in the current project directory.
 
 ## Mode
 
-If $ARGUMENTS matches a file in `<work.dir>/plans/` by exact filename or unambiguous prefix → refine mode. If ambiguous, list matches and ask.
+If $ARGUMENTS matches a file in `.work/plans/` by exact filename or unambiguous prefix → refine mode. If ambiguous, list matches and ask.
 If $ARGUMENTS is set → create mode using it as the feature description.
-If $ARGUMENTS is empty → list `<work.dir>/plans/`. None: ask what to plan. One: offer refine or new. Many: numbered list, ask to pick or describe a new feature.
+If $ARGUMENTS is empty → list `.work/plans/`. None: ask what to plan. One: offer refine or new. Many: numbered list, ask to pick or describe a new feature.
 
 ## Create mode
 
-1. Explore: read `CLAUDE.md`, scan directory, check `.claude/skills/` for available skills. Check for `<work.dir>/bootstrap.md` — if found, read it and note the tech stack, roles, and scaffolded entities as established context. Check `<work.dir>/research/` for a file matching the feature slug (`*<slug>*-research.md`) and for `health-check.md`. If found, read them — use `### Gaps & Recommendations` to inform clarifying questions and task decomposition. **Greenfield detection:** if the directory appears greenfield (no `CLAUDE.md`, no `<work.dir>/bootstrap.md`, and empty or near-empty), run `/resolve-rules mode:all scope:bootstrap` to check for a stack rule. If found, note this is a greenfield project and include "Scaffold project following rules" as task 1 in the plan. If no stack rule exists, proceed normally.
+1. Explore: read `CLAUDE.md`, scan directory, check `.claude/skills/` for available skills. Check for `.work/bootstrap.md` — if found, read it and note the tech stack, roles, and scaffolded entities as established context. Check `.work/research/` for a file matching the feature slug (`*<slug>*-research.md`) and for `health-check.md`. If found, read them — use `### Gaps & Recommendations` to inform clarifying questions and task decomposition. **Greenfield detection:** if the directory appears greenfield (no `CLAUDE.md`, no `.work/bootstrap.md`, and empty or near-empty), run `/resolve-rules mode:all scope:bootstrap` to check for a stack rule. If found, note this is a greenfield project and include "Scaffold project following rules" as task 1 in the plan. If no stack rule exists, proceed normally.
 2. Ask 3–5 clarifying questions. Wait for confirmation.
    - If bootstrap context was found: skip questions about tech stack, database, and auth approach (these are already decided). Focus on domain entities, business logic, scope boundaries, and constraints.
    - If no bootstrap context: ask as normal, including stack questions if the project's tech isn't clear from CLAUDE.md.
 3. Create tasks with `TaskCreate`. Make them small, meaningful, and ordered by dependency.
-4. Write the plan to `<work.dir>/plans/YYYY-MM-DD-<slug>.md`.
+4. Write the plan to `.work/plans/YYYY-MM-DD-<slug>.md`.
 5. **Gate:** run `ls` on the saved file path. If the file does not exist, go back to step 4. Do not proceed until the file is confirmed on disk.
 6. Ask the user to review. Once confirmed, suggest running `/design` to architect the feature.
 
 ## Refine mode
 
 1. Back up the current file — see [backup.md](../backup.md).
-2. Check `<work.dir>/research/` for matching research artifacts (new research may exist since the original plan). If found, note relevant findings.
+2. Check `.work/research/` for matching research artifacts (new research may exist since the original plan). If found, note relevant findings.
 3. Show current plan.
 4. Ask "What would you like to change?" Iterate until confirmed.
 5. Write the updated file once.

--- a/plugins/dl/skills/research/SKILL.md
+++ b/plugins/dl/skills/research/SKILL.md
@@ -9,19 +9,19 @@ Scan rules and codebase to produce structured context for the plan/design/implem
 
 ## Artifact — required output
 
-This skill produces a file in `<work.dir>/research/`. Every execution — create, re-entry, or health-check — must end with a saved artifact on disk. The wrap-up phase below is gated on this: do not summarise findings or suggest next steps until the artifact file has been written and verified with `ls`.
+This skill produces a file in `.work/research/`. Every execution — create, re-entry, or health-check — must end with a saved artifact on disk. The wrap-up phase below is gated on this: do not summarise findings or suggest next steps until the artifact file has been written and verified with `ls`.
 
 ## Config
 
-Read `devenv.json` from `${CLAUDE_PLUGIN_ROOT}/devenv.json` (if running as a plugin) or `~/.claude/devenv.json` (fallback). Keys: `work.dir` (default `.work`).
+All artifacts are stored under `.work/` in the current project directory.
 
 ## Mode
 
 Parse `$ARGUMENTS`:
 
-- Matches an existing file in `<work.dir>/research/` by slug → **re-entry** (append dated section).
+- Matches an existing file in `.work/research/` by slug → **re-entry** (append dated section).
 - Set but no match → **create** new research file.
-- Empty → **health-check** mode. Before starting, confirm with the user: "This will run a full project health check (all rules + full codebase scan). This can take a while. Continue, or would you like to research a specific topic instead?" If they provide a topic, switch to create mode. If they confirm, proceed — writes to `<work.dir>/research/health-check.md`.
+- Empty → **health-check** mode. Before starting, confirm with the user: "This will run a full project health check (all rules + full codebase scan). This can take a while. Continue, or would you like to research a specific topic instead?" If they provide a topic, switch to create mode. If they confirm, proceed — writes to `.work/research/health-check.md`.
 
 ## Rule scan
 
@@ -40,13 +40,13 @@ For each matched rule, extract:
 
 1. Read `CLAUDE.md` if present.
 2. Scan project directory structure (top-level + key subdirectories).
-3. Check for `<work.dir>/bootstrap.md` — read if found.
+3. Check for `.work/bootstrap.md` — read if found.
 4. Search code for patterns relevant to the topic — look for existing implementations, inconsistencies, multiple approaches, tech choices.
 5. Note anything that might affect planning or design.
 
 ## Output
 
-Write to `<work.dir>/research/YYYY-MM-DD-<slug>-research.md` (or `health-check.md` for health-check mode).
+Write to `.work/research/YYYY-MM-DD-<slug>-research.md` (or `health-check.md` for health-check mode).
 
 **Gate:** run `ls` on the saved file path. If the file does not exist, write it now. Do not proceed to the wrap-up phase until the file is confirmed on disk.
 


### PR DESCRIPTION
## Summary

- Hardcode `.work/` as the artifact directory across all skills instead of reading from `devenv.json`
- Remove `devenv.json` entirely (also eliminates `backups.maxPerArtifact` config, hardcoded to 5 in `backup.md`)
- Remove all `<work.dir>` placeholder indirection from skill definitions (25+ occurrences across 6 skills)

## Why

The configurable work directory added cognitive overhead for Claude without practical benefit — nobody ever changed the default, and the companion bin scripts in devenv already hardcoded `.work/`. The `~/.claude/devenv.json` fallback path was also a dead reference.

## Test plan

- [x] Run each skill (`/dl:research`, `/dl:plan`, `/dl:design`, `/dl:implement`, `/dl:bootstrap`) and verify artifacts are written to `.work/`
- [x] Verify refine mode still creates backups with max count of 5