### PR TITLE
Add checklist pattern and imperative rewrite to all skills, bump to 2.0.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "dl",
       "description": "Structured development workflow for Claude Code — research, plan, design, implement",
-      "version": "1.3.0",
+      "version": "2.0.0",
       "source": "./plugins/dl"
     }
   ]

--- a/plugins/dl/.claude-plugin/plugin.json
+++ b/plugins/dl/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dl",
   "description": "Structured development workflow for Claude Code — research, plan, design, implement",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "author": {
     "name": "minusblindfold"
   },

--- a/plugins/dl/skills/bootstrap/SKILL.md
+++ b/plugins/dl/skills/bootstrap/SKILL.md
@@ -5,23 +5,47 @@ argument-hint: "<project-name> [description]"
 allowed-tools: Read Write Bash
 ---
 
-Scaffold a new project driven entirely by resolved rule docs.
+Execute each section below in order. Do not skip sections.
+
+1. Determine your mode.
+2. Copy the **Task Progress** checklist from that mode's section into your response.
+3. Work through each item. Check it off as you complete it.
+4. Do not proceed past a **Gate** until the gate condition is verified.
 
 ## Config
 
 All artifacts are stored under `.work/` in the current project directory.
 
-## Resolve rules
+## Bootstrap mode
+
+Copy this checklist and check off items as you complete them:
+
+```
+Task Progress:
+- [ ] Run /resolve-rules mode:all scope:bootstrap
+- [ ] Verify stack rule exists
+- [ ] Parse arguments for project name and description
+- [ ] Ask for missing inputs
+- [ ] Confirm inputs with user
+- [ ] Generate project skeleton from stack rule
+- [ ] Apply rule contributions in dependency order
+- [ ] Generate CLAUDE.md
+- [ ] Write .work/bootstrap.md context marker
+- [ ] Gate: verify bootstrap.md with ls
+- [ ] Wrap up: summarize generated files, suggest next steps
+```
+
+### Resolve rules
 
 Run `/resolve-rules mode:all scope:bootstrap` to resolve every rule that applies at bootstrap time. Read all resolved docs.
 
-If `/resolve-rules` is unavailable, warn the user: "Rule resolution skill not found — rules will not be applied." Then stop.
+If `/resolve-rules` is unavailable, print: "Rule resolution unavailable — cannot bootstrap without rules." Then stop.
 
 If no rules are resolved, stop: "No rules found. Add at least a `stack.md` to your rules directory, or install a rule pack from [devloop-rules](https://github.com/minusblindfold/devloop-rules). See `rules/rules.md` in the devloop plugin for the format."
 
 Look for a **Stack** rule (matched by H1 title or `stack` keyword). If no stack rule is found, stop: "No stack rule found. Bootstrap needs a stack rule to know what kind of project to generate."
 
-## Gather inputs
+### Gather inputs
 
 1. Parse `$ARGUMENTS` for the project name (first word) and optional description (rest). If no project name, ask.
 2. From the stack rule, identify the technology stack and present a summary to the user.
@@ -31,15 +55,17 @@ Look for a **Stack** rule (matched by H1 title or `stack` keyword). If no stack 
    - If the stack rule uses packages or modules, ask for the **root namespace/group**.
 4. Confirm inputs with the user before generating.
 
-## Generate project
+### Generate project
+
+**Constraint:** Generate only the scaffold. Feature code belongs in /plan → /design → /implement.
 
 Create all files in the **current working directory**. The directory should be empty or near-empty. If not empty, warn the user and ask to confirm.
 
-### Skeleton
+#### Skeleton
 
 Read the stack rule fully. Generate the project skeleton it describes: build file, settings, config files, main entry point, wrapper, gitignore, and test config. Derive names (database name, package name, artifact name) from the project name.
 
-### Rule contributions
+#### Rule contributions
 
 Work through each remaining resolved rule that has a `## Bootstrap` section. Process them in natural dependency order: infrastructure → data layer → security → business logic → UI.
 
@@ -50,14 +76,14 @@ For each rule:
 
 Skip rules that have no `## Bootstrap` section — they apply during feature work, not scaffolding.
 
-### Project documentation
+#### Project documentation
 
 Generate a `CLAUDE.md` tailored to the project. Derive everything from what was actually generated:
 - Project overview (name, description, tech stack from stack rule).
 - Common commands (build, run, test — from stack rule's startup section).
 - Architecture overview (layers, security config, database, frontend — from the rules that were applied).
 
-## Write bootstrap context marker
+### Write bootstrap context marker
 
 Create `.work/bootstrap.md` in the project directory. Assemble it dynamically from what was resolved and generated:
 
@@ -82,7 +108,11 @@ Create `.work/bootstrap.md` in the project directory. Assemble it dynamically fr
 
 This marker is read by `/plan` and `/design` to skip redundant questions about established architecture.
 
-## Wrap up
+### Gate
+
+Run `ls` on `.work/bootstrap.md`. If the file does not exist, write it now. Do not proceed until the file is confirmed on disk.
+
+### Wrap up
 
 1. Print a summary of what was generated (file count by category).
 2. Suggest next steps derived from the stack rule's startup section:
@@ -93,9 +123,9 @@ This marker is read by `/plan` and `/design` to skip redundant questions about e
 
 ## Rules
 
-- Never generate features beyond the minimal scaffold — that's what `/plan` → `/design` → `/implement` is for.
+- Generate only the scaffold. Feature code belongs in /plan → /design → /implement.
 - Follow rule docs exactly. If a pattern isn't covered by a rule doc, keep it simple and consistent with the rules that do exist.
-- No hardcoded version numbers in generated code. Use latest stable versions at generation time.
+- Do not hardcode version numbers in generated code. Use latest stable versions at generation time.
 - The bootstrap context marker goes in the project's `.work/`, not in devenv.
-- Never hardcode technology choices in this skill. Every file generated must trace back to a resolved rule.
+- Do not hardcode technology choices in this skill. Every file generated must trace back to a resolved rule.
 - If no rules are resolved, do not guess a stack. Stop and tell the user.

--- a/plugins/dl/skills/design/SKILL.md
+++ b/plugins/dl/skills/design/SKILL.md
@@ -5,11 +5,16 @@ argument-hint: "[plan slug]"
 allowed-tools: Read Write Bash TaskCreate
 ---
 
-Create or refine a feature design.
+Execute each section below in order. Do not skip sections.
+
+1. Determine your mode.
+2. Copy the **Task Progress** checklist from that mode's section into your response.
+3. Work through each item. Check it off as you complete it.
+4. Do not proceed past a **Gate** until the gate condition is verified.
 
 ## Artifact — required output
 
-This skill produces files in `.work/designs/` (and `.work/plans/` in bootstrap mode). Every execution — create, bootstrap, or refine — must end with saved artifacts on disk. The review phase below is gated on this: do not present the design to the user or suggest next steps until all artifact files have been written and verified with `ls`.
+Write design files to `.work/designs/` (and `.work/plans/` in bootstrap mode). Save all artifacts before proceeding to wrap up. Do not present the design to the user or suggest next steps until all artifact files have been written and verified with `ls`.
 
 ## Config
 
@@ -22,36 +27,94 @@ If $ARGUMENTS is empty → list designs. None: fall through to plan picker. One:
 
 Plan picker: list `.work/plans/`. None → ask "What would you like to design?" and enter bootstrap mode. One → auto-select. Many → ask.
 
-## Bootstrap mode
-
-For simple features where no plan exists yet. Treats $ARGUMENTS as the feature description.
-
-1. Ask 1–2 focused clarifying questions (scope and any key constraints). Wait for answers.
-2. Create a minimal plan — typically 1–3 tasks — using the format in the `/plan` skill's `## Plan format` section.
-3. Write the plan to `.work/plans/YYYY-MM-DD-<slug>.md`. **Gate:** run `ls` on the file path — do not proceed to create mode until the file is confirmed on disk.
-4. Confirm the plan with the user ("Here's the plan I'll design from — does this look right?"). Adjust if needed.
-5. Proceed to create mode using the saved plan.
-
 ## Create mode
 
-1. Read plan: extract name, tasks, dependencies.
-2. Explore codebase: read `CLAUDE.md`, scan directory, check `.claude/skills/`. Check for `.work/bootstrap.md` — if found, read it. The architecture section should reference the bootstrapped stack as established rather than proposing it.
-3. Ask 2–3 questions. Wait for confirmation.
-   - If bootstrap context was found: skip architecture-style questions (already decided). Focus on design-specific questions — data relationships, UI flow, edge cases.
+**Constraint:** Do not write code. This skill produces a design, not an implementation.
+
+Copy this checklist and check off items as you complete them:
+
+```
+Task Progress:
+- [ ] Read plan: extract name, tasks, dependencies
+- [ ] Read CLAUDE.md and scan directory
+- [ ] Check for .work/bootstrap.md
+- [ ] Ask 2–3 clarifying questions
+- [ ] Write design doc (Overview, Architecture, Task Specs)
+- [ ] Write Mermaid diagrams to .work/designs/diagrams/
+- [ ] Write design to .work/designs/
+- [ ] Gate: verify design file and .mmd files with ls
+- [ ] Present design for review
+```
+
+1. Read the plan. Extract name, tasks, and dependencies.
+2. Read `CLAUDE.md` if present. Scan the project directory.
+   2a. Check `.claude/skills/` for available skills.
+   2b. Check for `.work/bootstrap.md` — if found, read it. Reference the bootstrapped stack as established, not proposed.
+3. Ask 2–3 clarifying questions. Wait for answers.
+   - If bootstrap context was found: skip architecture-style questions (already decided). Focus on data relationships, UI flow, edge cases.
    - If no bootstrap context: ask as normal, including architecture style if unclear.
-4. Write design doc with: Overview, Architecture, Diagrams, Task Specs.
-5. Choose diagrams that best illuminate the plan — see [diagrams.md](diagrams.md). A feature may warrant more than one; omit diagrams for trivial tasks. Save each as a `.mmd` file in `.work/designs/diagrams/`. List them in the doc; do not embed code inline.
-6. For each plan task write a spec: Goal, Interfaces, Implementation notes, Acceptance criteria, Dependencies. Also note which rules apply by title (e.g., `**Rules:** JPA Entity Rules, Liquibase Migration Rules`). This tells `/implement` which docs to apply via `/resolve-rules` explicit mode.
-7. Write the design to `.work/designs/YYYY-MM-DD-<slug>-design.md`.
-8. **Gate:** run `ls` on the design file and each `.mmd` file. If any are missing, write them now. Do not proceed until all files are confirmed on disk.
-9. Ask the user to review. Once confirmed, suggest running `/implement` to begin.
+4. Write the Overview and Architecture sections.
+5. Choose diagrams that best illuminate the plan — see [diagrams.md](diagrams.md). A feature may warrant more than one; omit diagrams for trivial tasks. Save each as a `.mmd` file in `.work/designs/diagrams/`. List them in the doc; do not embed diagram code inline.
+6. Write a spec for each plan task: Goal, Interfaces, Implementation notes, Acceptance criteria, Tests, Dependencies. Note which rules apply by title (e.g., `**Rules:** JPA Entity Rules, Liquibase Migration Rules`). This tells `/implement` which docs to apply via `/resolve-rules` explicit mode.
+7. Write the complete design to `.work/designs/YYYY-MM-DD-<slug>-design.md`.
+
+### Gate
+
+Run `ls` on the design file and each `.mmd` file. If any are missing, write them now. Do not proceed until all files are confirmed on disk.
+
+### Wrap up
+
+Ask the user to review. Once confirmed, suggest running `/implement` to begin.
+
+## Bootstrap mode
+
+For simple features where no plan exists yet. Treat $ARGUMENTS as the feature description.
+
+Copy this checklist and check off items as you complete them:
+
+```
+Task Progress:
+- [ ] Ask 1–2 clarifying questions
+- [ ] Create minimal plan (1–3 tasks)
+- [ ] Write plan to .work/plans/
+- [ ] Gate: verify plan file with ls
+- [ ] Confirm plan with user
+- [ ] Proceed to create mode
+```
+
+1. Ask 1–2 focused clarifying questions (scope and key constraints). Wait for answers.
+2. Create a minimal plan — typically 1–3 tasks — using the format in the `/plan` skill's `## Plan format` section.
+3. Write the plan to `.work/plans/YYYY-MM-DD-<slug>.md`.
+
+### Gate
+
+Run `ls` on the file path. Do not proceed to create mode until the file is confirmed on disk.
+
+### Next
+
+Confirm the plan with the user ("Here's the plan I'll design from — does this look right?"). Adjust if needed. Then proceed to create mode using the saved plan.
 
 ## Refine mode
 
+Copy this checklist and check off items as you complete them:
+
+```
+Task Progress:
+- [ ] Back up current file
+- [ ] Show current design
+- [ ] Ask what to change — iterate until confirmed
+- [ ] Write updated file and .mmd files
+- [ ] Gate: verify all files with ls
+```
+
 1. Back up the current file — see [backup.md](../backup.md).
-2. Show current design.
+2. Show the current design.
 3. Ask "What would you like to change?" Iterate until confirmed.
-4. Write updated file and `.mmd` files once.
+4. Write the updated file and `.mmd` files once.
+
+### Gate
+
+Run `ls` on the design file and each `.mmd` file. If any are missing, write them now. Do not proceed until all files are confirmed on disk.
 
 ## Design format
 
@@ -90,6 +153,6 @@ _(include only the diagrams that apply)_
 
 ## Rules
 
-- Never implement.
+- Do not write code. This skill produces a design, not an implementation.
 - Only reference skills found in `.claude/skills/`.
 - Stay grounded in the plan — do not invent tasks.

--- a/plugins/dl/skills/implement/SKILL.md
+++ b/plugins/dl/skills/implement/SKILL.md
@@ -5,11 +5,16 @@ argument-hint: "[plan-slug] [task-number]"
 allowed-tools: Read Write Edit Bash(git:*) TaskCreate TaskList TaskUpdate
 ---
 
-Implement one task from a plan+design pair.
+Execute each section below in order. Do not skip sections.
+
+1. Determine your mode.
+2. Copy the **Task Progress** checklist from that mode's section into your response.
+3. Work through each item. Check it off as you complete it.
+4. Do not proceed past a **Gate** until the gate condition is verified.
 
 ## Artifact — required output
 
-This skill produces an implementation note in `.work/implementations/`. Every execution — even if the task is incomplete — must end with a saved artifact on disk. The wrap-up phase below is gated on this: do not summarise changes, suggest commits, or recommend next steps until the implementation note has been written and verified with `ls`.
+Write an implementation note to `.work/implementations/`. Save the artifact before proceeding to wrap up — even if the task is incomplete. Do not summarize changes, suggest commits, or recommend next steps until the implementation note has been written and verified with `ls`.
 
 ## Config
 
@@ -17,30 +22,54 @@ All artifacts are stored under `.work/` in the current project directory.
 
 ## Find the feature
 
-If $ARGUMENTS: treat as `<slug>` or `<slug> <task-N>`. Find plan in `.work/plans/`, then matching design in `.work/designs/`. Missing design → "No design found for '<slug>'. Run /design first." and stop.
-If no argument: list plans and designs, match by slug. No pairs → "Run /plan then /design first." and stop. One pair → show it and ask to confirm or describe a new feature. Many → numbered list, ask to pick.
+If $ARGUMENTS: treat as `<slug>` or `<slug> <task-N>`. Find the plan in `.work/plans/`, then the matching design in `.work/designs/`. Missing design → print "No design found for '<slug>'. Run /design first." and stop.
+If no argument: list plans and designs, match by slug. No pairs → print "Run /plan then /design first." and stop. One pair → show it and ask to confirm or describe a new feature. Many → numbered list, ask to pick.
 
-## Load and sync
+## Implement mode
 
-1. Read both files in full.
+Copy this checklist and check off items as you complete them:
+
+```
+Task Progress:
+- [ ] Find plan and design by slug
+- [ ] Read plan, design, and .mmd diagrams
+- [ ] Check .claude/skills/ for available skills
+- [ ] Sync tasks to Claude Code task list
+- [ ] Pick task and mark in_progress
+- [ ] Run /resolve-rules for applicable rules
+- [ ] Read relevant files
+- [ ] Run baseline tests
+- [ ] Implement against task spec
+- [ ] Re-run tests
+- [ ] Mark task completed
+- [ ] Write implementation note to .work/implementations/
+- [ ] Gate: verify implementation note with ls
+- [ ] Wrap up: summarize, note deviations, suggest commit
+```
+
+### Load and sync
+
+1. Read the plan and design files in full.
 2. Read any `.mmd` diagrams referenced in the design from `.work/designs/diagrams/`. Use them to understand the proposed architecture and flow before implementing.
 3. Check `.claude/skills/` for available skills. Print what's found.
-4. Sync plan tasks to Claude Code task list: call `TaskList`, then `TaskCreate` for any task not already present.
-5. Print task list with completion status.
+4. Sync plan tasks to Claude Code task list: call `TaskList`, then `TaskCreate` for any task not already present. Match by subject before creating — do not duplicate.
+5. Print the task list with completion status.
 
-## Pick a task
+### Pick a task
 
 If $ARGUMENTS includes a task number, use it. Otherwise ask. Warn if dependencies are incomplete. Mark `in_progress` with `TaskUpdate`.
 
-## Apply rules
+### Apply rules
 
 If the design's task spec includes a `**Rules:**` line, run `/resolve-rules mode:explicit <titles>`. Otherwise, run `/resolve-rules mode:keyword <task description terms>`.
 
-If `/resolve-rules` is unavailable, warn the user: "Rule resolution skill not found — rules will not be applied." Then continue without rules.
+If `/resolve-rules` is unavailable, print: "Rule resolution unavailable — continuing without rules." Then continue.
 
 Follow the matched rule docs when creating or modifying files that fall under their scope.
 
-## Implement
+### Execute
+
+**Constraint:** Implement only the selected task. Note out-of-scope discoveries in the implementation note rather than acting on them.
 
 1. Read all relevant files before editing.
 2. Run relevant tests if available to establish a baseline.
@@ -49,18 +78,24 @@ Follow the matched rule docs when creating or modifying files that fall under th
 5. Re-run tests. Note any failures or unexpected results.
 6. Mark `completed` with `TaskUpdate` when fully done.
 
-## Wrap up
+### Write implementation note
 
-1. Write an implementation note — see [implementation-note.md](implementation-note.md).
-2. **Gate:** run `ls` on the saved file path. If the file does not exist, go back to step 1. Do not proceed until the file is confirmed on disk.
-3. Summarise changes (files created/modified).
-4. Note any deviations from the design spec — interfaces, structures, or approaches that changed. If significant, suggest running `/design` refine before the next task.
-5. If out-of-scope work was discovered, suggest running `/plan` refine to capture it.
-6. Suggest a git commit scoped to this task.
-7. Recommend follow-up skills — only skills found in `.claude/skills/`.
+Write the note — see [implementation-note.md](implementation-note.md). Save to `.work/implementations/YYYY-MM-DD-<slug>-task-N.md`.
+
+### Gate
+
+Run `ls` on the saved file path. If the file does not exist, go back and write it. Do not proceed until the file is confirmed on disk.
+
+### Wrap up
+
+1. Summarize changes (files created/modified).
+2. Note any deviations from the design spec — interfaces, structures, or approaches that changed. If significant, suggest running `/design refine` before the next task.
+3. If out-of-scope work was discovered, suggest running `/plan refine` to capture it.
+4. Suggest a git commit scoped to this task.
+5. Recommend follow-up skills — only skills found in `.claude/skills/`.
 
 ## Rules
 
-- Never start without a design file.
-- Never duplicate tasks — match by subject before creating.
+- Do not start without a design file.
+- Do not duplicate tasks — match by subject before creating.
 - Implement only the selected task. Note out-of-scope discoveries in the implementation note rather than acting on them.

--- a/plugins/dl/skills/plan/SKILL.md
+++ b/plugins/dl/skills/plan/SKILL.md
@@ -5,11 +5,16 @@ argument-hint: "[feature description]"
 allowed-tools: Read Write Bash TaskCreate
 ---
 
-Create or refine a feature plan.
+Execute each section below in order. Do not skip sections.
+
+1. Determine your mode.
+2. Copy the **Task Progress** checklist from that mode's section into your response.
+3. Work through each item. Check it off as you complete it.
+4. Do not proceed past a **Gate** until the gate condition is verified.
 
 ## Artifact — required output
 
-This skill produces a file in `.work/plans/`. Every execution — create or refine — must end with a saved artifact on disk. The wrap-up phase below is gated on this: do not present results to the user or suggest next steps until the artifact file has been written and verified with `ls`.
+Write the artifact to `.work/plans/`. Save the artifact before proceeding to wrap up. Do not present results to the user or suggest next steps until the artifact file has been written and verified with `ls`.
 
 ## Config
 
@@ -17,28 +22,73 @@ All artifacts are stored under `.work/` in the current project directory.
 
 ## Mode
 
-If $ARGUMENTS matches a file in `.work/plans/` by exact filename or unambiguous prefix → refine mode. If ambiguous, list matches and ask.
-If $ARGUMENTS is set → create mode using it as the feature description.
+If $ARGUMENTS matches a file in `.work/plans/` by exact filename or unambiguous prefix → **refine** mode. If ambiguous, list matches and ask.
+If $ARGUMENTS is set → **create** mode using it as the feature description.
 If $ARGUMENTS is empty → list `.work/plans/`. None: ask what to plan. One: offer refine or new. Many: numbered list, ask to pick or describe a new feature.
 
 ## Create mode
 
-1. Explore: read `CLAUDE.md`, scan directory, check `.claude/skills/` for available skills. Check for `.work/bootstrap.md` — if found, read it and note the tech stack, roles, and scaffolded entities as established context. Check `.work/research/` for a file matching the feature slug (`*<slug>*-research.md`) and for `health-check.md`. If found, read them — use `### Gaps & Recommendations` to inform clarifying questions and task decomposition. **Greenfield detection:** if the directory appears greenfield (no `CLAUDE.md`, no `.work/bootstrap.md`, and empty or near-empty), run `/resolve-rules mode:all scope:bootstrap` to check for a stack rule. If found, note this is a greenfield project and include "Scaffold project following rules" as task 1 in the plan. If no stack rule exists, proceed normally.
-2. Ask 3–5 clarifying questions. Wait for confirmation.
-   - If bootstrap context was found: skip questions about tech stack, database, and auth approach (these are already decided). Focus on domain entities, business logic, scope boundaries, and constraints.
+**Constraint:** Do not write code. This skill produces a plan, not an implementation.
+
+Copy this checklist and check off items as you complete them:
+
+```
+Task Progress:
+- [ ] Read CLAUDE.md
+- [ ] Scan project directory and .claude/skills/
+- [ ] Check for .work/bootstrap.md
+- [ ] Check .work/research/ for matching artifacts
+- [ ] Check for greenfield project
+- [ ] Ask 3–5 clarifying questions
+- [ ] Create tasks with TaskCreate
+- [ ] Write plan to .work/plans/
+- [ ] Gate: verify plan file with ls
+- [ ] Present plan for review
+```
+
+1. Read `CLAUDE.md` if present.
+   1a. Scan project directory structure (top-level + key subdirectories).
+   1b. Check `.claude/skills/` for available skills.
+   1c. Check for `.work/bootstrap.md` — if found, read it. Note tech stack, roles, and scaffolded entities as established context.
+   1d. Check `.work/research/` for a file matching the feature slug (`*<slug>*-research.md`) and for `health-check.md`. If found, read them. Use `### Gaps & Recommendations` to inform clarifying questions and task decomposition.
+   1e. **Greenfield detection:** if no `CLAUDE.md`, no `.work/bootstrap.md`, and directory is empty or near-empty → run `/resolve-rules mode:all scope:bootstrap` to check for a stack rule. If stack rule found, include "Scaffold project following rules" as task 1 in the plan. If no stack rule exists, proceed normally. If `/resolve-rules` is unavailable, print: "Rule resolution unavailable — continuing without rules." Then continue.
+2. Ask 3–5 clarifying questions. Wait for answers.
+   - If bootstrap context was found: skip questions about tech stack, database, and auth approach (already decided). Focus on domain entities, business logic, scope boundaries, and constraints.
    - If no bootstrap context: ask as normal, including stack questions if the project's tech isn't clear from CLAUDE.md.
-3. Create tasks with `TaskCreate`. Make them small, meaningful, and ordered by dependency.
+3. Create tasks with `TaskCreate`. Make tasks small. Order by dependency.
 4. Write the plan to `.work/plans/YYYY-MM-DD-<slug>.md`.
-5. **Gate:** run `ls` on the saved file path. If the file does not exist, go back to step 4. Do not proceed until the file is confirmed on disk.
-6. Ask the user to review. Once confirmed, suggest running `/design` to architect the feature.
+
+### Gate
+
+Run `ls` on the saved file path. If the file does not exist, go back to step 4. Do not proceed until the file is confirmed on disk.
+
+### Wrap up
+
+Ask the user to review. Once confirmed, suggest running `/design` to architect the feature.
 
 ## Refine mode
 
+Copy this checklist and check off items as you complete them:
+
+```
+Task Progress:
+- [ ] Back up current file
+- [ ] Check .work/research/ for new artifacts
+- [ ] Show current plan
+- [ ] Ask what to change — iterate until confirmed
+- [ ] Write updated plan file
+- [ ] Gate: verify plan file with ls
+```
+
 1. Back up the current file — see [backup.md](../backup.md).
 2. Check `.work/research/` for matching research artifacts (new research may exist since the original plan). If found, note relevant findings.
-3. Show current plan.
+3. Show the current plan.
 4. Ask "What would you like to change?" Iterate until confirmed.
 5. Write the updated file once.
+
+### Gate
+
+Run `ls` on the saved file path. If the file does not exist, go back to step 5. Do not proceed until the file is confirmed on disk.
 
 ## Plan format
 
@@ -54,11 +104,11 @@ If $ARGUMENTS is empty → list `.work/plans/`. None: ask what to plan. One: off
 - [ ] ...
 ```
 
-Tasks should be small and ordered by dependency. Each task includes a one-line "Done when" acceptance criterion so `/design` can expand it into a full spec without guessing intent.
+Make tasks small. Order by dependency. Each task includes a one-line "Done when" acceptance criterion so `/design` can expand it into a full spec without guessing intent.
 
 ## Rules
 
-- Never implement.
+- Do not write code. This skill produces a plan, not an implementation.
 - Only reference skills found in `.claude/skills/`.
 - Right-size tasks — small over large.
 - In refine mode, write once at the end.

--- a/plugins/dl/skills/research/SKILL.md
+++ b/plugins/dl/skills/research/SKILL.md
@@ -5,11 +5,16 @@ argument-hint: "[feature-slug or topic]"
 allowed-tools: Read Bash Glob Grep
 ---
 
-Scan rules and codebase to produce structured context for the plan/design/implement cycle.
+Execute each section below in order. Do not skip sections.
+
+1. Determine your mode.
+2. Copy the **Task Progress** checklist from that mode's section into your response.
+3. Work through each item. Check it off as you complete it.
+4. Do not proceed past a **Gate** until the gate condition is verified.
 
 ## Artifact — required output
 
-This skill produces a file in `.work/research/`. Every execution — create, re-entry, or health-check — must end with a saved artifact on disk. The wrap-up phase below is gated on this: do not summarise findings or suggest next steps until the artifact file has been written and verified with `ls`.
+Write the artifact to `.work/research/`. Save the artifact before proceeding to wrap up. Do not summarize findings or suggest next steps until the artifact file has been written and verified with `ls`.
 
 ## Config
 
@@ -21,34 +26,51 @@ Parse `$ARGUMENTS`:
 
 - Matches an existing file in `.work/research/` by slug → **re-entry** (append dated section).
 - Set but no match → **create** new research file.
-- Empty → **health-check** mode. Before starting, confirm with the user: "This will run a full project health check (all rules + full codebase scan). This can take a while. Continue, or would you like to research a specific topic instead?" If they provide a topic, switch to create mode. If they confirm, proceed — writes to `.work/research/health-check.md`.
+- Empty → **health-check** mode. Ask the user: "This will run a full project health check (all rules + full codebase scan). This can take a while. Continue, or would you like to research a specific topic instead?" If they provide a topic, switch to create mode. If they confirm, proceed.
 
-## Rule scan
+## Create mode
 
-Run `/resolve-rules` to discover rules:
-- If topic provided → `mode:keyword <topic>` (match topic against frontmatter keywords).
-- If health-check → `mode:all` (return every resolved rule).
+Copy this checklist and check off items as you complete them:
 
-If `/resolve-rules` is unavailable, warn the user: "Rule resolution skill not found — rules will not be applied." Then continue without rules.
+```
+Task Progress:
+- [ ] Determine mode (create / re-entry / health-check)
+- [ ] Run rule scan via /resolve-rules
+- [ ] Read CLAUDE.md
+- [ ] Scan project directory structure
+- [ ] Check for .work/bootstrap.md
+- [ ] Search codebase for topic-relevant patterns
+- [ ] Write artifact to .work/research/
+- [ ] Gate: verify artifact with ls
+- [ ] Wrap up: summarize and suggest next steps
+```
+
+### Rule scan
+
+Run `/resolve-rules`:
+- Topic provided → `mode:keyword <topic>`.
+- Health-check → `mode:all`.
+
+If `/resolve-rules` is unavailable, print: "Rule resolution unavailable — continuing without rules." Then continue.
 
 For each matched rule, extract:
 - Title (H1 heading)
 - Source layer path
 - First 3–5 key patterns
 
-## Codebase scan
+### Codebase scan
+
+**Constraint:** Do not modify project files. This skill produces context, not code.
 
 1. Read `CLAUDE.md` if present.
 2. Scan project directory structure (top-level + key subdirectories).
 3. Check for `.work/bootstrap.md` — read if found.
-4. Search code for patterns relevant to the topic — look for existing implementations, inconsistencies, multiple approaches, tech choices.
+4. Search code for patterns relevant to the topic. Look for existing implementations, inconsistencies, multiple approaches, tech choices.
 5. Note anything that might affect planning or design.
 
-## Output
+### Output
 
 Write to `.work/research/YYYY-MM-DD-<slug>-research.md` (or `health-check.md` for health-check mode).
-
-**Gate:** run `ls` on the saved file path. If the file does not exist, write it now. Do not proceed to the wrap-up phase until the file is confirmed on disk.
 
 ```markdown
 # <Topic> Research
@@ -72,25 +94,56 @@ Write to `.work/research/YYYY-MM-DD-<slug>-research.md` (or `health-check.md` fo
 - [ ] <actionable item>
 ```
 
-## Re-entry
+### Gate
 
-If appending to an existing file:
-1. Read the existing file in full.
-2. Append a new `## YYYY-MM-DD — <description>` section at the end.
-3. Never overwrite or modify prior sections.
+Run `ls` on the saved file path. If the file does not exist, write it now. Do not proceed to wrap up until the file is confirmed on disk.
 
-## Wrap up
+### Wrap up
 
-- Summarise what was found: rules matched, patterns observed, recommendations count.
-- Suggest next steps:
-  - `/plan` or `/plan <slug>` to start planning from findings.
-  - `/plan refine` if recommendations affect an existing plan.
-  - `/design` if a plan already exists and findings inform architecture.
+1. Summarize what was found: rules matched, patterns observed, recommendations count.
+2. Suggest next steps:
+   - `/plan` or `/plan <slug>` to start planning from findings.
+   - `/plan refine` if recommendations affect an existing plan.
+   - `/design` if a plan already exists and findings inform architecture.
+
+## Re-entry mode
+
+Copy this checklist and check off items as you complete them:
+
+```
+Task Progress:
+- [ ] Read existing research file in full
+- [ ] Run rule scan via /resolve-rules
+- [ ] Scan codebase for new patterns
+- [ ] Append new dated section to artifact
+- [ ] Gate: verify artifact with ls
+- [ ] Wrap up: summarize and suggest next steps
+```
+
+**Constraint:** Do not modify project files. This skill produces context, not code.
+
+1. Read the existing research file in full.
+2. Run `/resolve-rules` as described in the create mode rule scan section.
+3. Scan the codebase for new patterns relevant to the topic.
+4. Append a new `## YYYY-MM-DD — <description>` section at the end. Do not overwrite or modify prior sections.
+
+### Gate
+
+Run `ls` on the saved file path. If the file does not exist, write it now. Do not proceed to wrap up until the file is confirmed on disk.
+
+### Wrap up
+
+1. Summarize new findings: rules matched, patterns observed, recommendations count.
+2. Suggest next steps as in create mode.
+
+## Health-check mode
+
+Follow the create mode checklist and steps, but use `mode:all` for rule scan and write to `.work/research/health-check.md`.
 
 ## Rules
 
-- Never implement. This skill produces context, not code.
-- Never overwrite prior research sections on re-entry.
-- Rule discovery must use the resolution algorithm — never hardcode paths.
-- Keep recommendations actionable and scoped — avoid vague suggestions.
-- If no rules match and no relevant codebase patterns are found, say so clearly rather than padding the output.
+- Do not modify project files. This skill produces context, not code.
+- Do not overwrite prior research sections on re-entry.
+- Use the resolution algorithm for rule discovery — do not hardcode paths.
+- Keep recommendations actionable and scoped — do not pad with vague suggestions.
+- If no rules match and no relevant codebase patterns are found, say so clearly.

--- a/plugins/dl/skills/resolve-rules/SKILL.md
+++ b/plugins/dl/skills/resolve-rules/SKILL.md
@@ -5,7 +5,21 @@ user-invocable: false
 allowed-tools: Read, Glob, Grep
 ---
 
-Discover and read rule docs from the base rules directory and any configured layers.
+Execute each section below in order. Do not skip sections.
+
+1. Copy the **Task Progress** checklist below into your response.
+2. Work through each item. Check it off as you complete it.
+
+```
+Task Progress:
+- [ ] Parse mode and scope from $ARGUMENTS
+- [ ] Build layer list (user → project → shared → plugin)
+- [ ] Walk layers, build resolution map
+- [ ] Apply mode matching (all / keyword / explicit)
+- [ ] Merge always-scoped rules
+- [ ] Apply scope filter if present
+- [ ] Print matched rules or "No rules apply"
+```
 
 ## Input
 
@@ -20,7 +34,7 @@ If $ARGUMENTS is empty, default to `mode:all`.
 
 ## Resolution
 
-### Determine mode
+### Build the layer list
 
 Build the layer list using four tiers (highest precedence first):
 
@@ -31,10 +45,10 @@ Build the layer list using four tiers (highest precedence first):
 | 3 | Shared/org | `~/devloop/rules/` | Rule packs managed by devloop CLI |
 | 4 (lowest) | Plugin-bundled | `${CLAUDE_PLUGIN_ROOT}/rules/` | Defaults shipped with devloop |
 
-1. Check if `~/.claude/rules/` exists (user rules). If so, add it as the highest-precedence layer.
-2. Check if `{cwd}/devloop/rules/` exists (project rules). If so, add it as the next layer. Skip silently if it doesn't exist.
-3. Check if `~/devloop/rules/` exists (shared/org rule packs). If so, scan this directory and all its subdirectories — each subdirectory is an enabled pack. Add all discovered rule directories as layers. Skip silently if it doesn't exist.
-4. Check if `${CLAUDE_PLUGIN_ROOT}/rules/` exists (plugin-bundled rules). If so, add it as the lowest-precedence layer.
+1. Check if `~/.claude/rules/` exists. If so, add it as the highest-precedence layer.
+2. Check if `{cwd}/devloop/rules/` exists. If so, add it as the next layer. Skip silently if missing.
+3. Check if `~/devloop/rules/` exists. If so, scan this directory and all subdirectories — each subdirectory is an enabled pack. Add all discovered rule directories as layers. Skip silently if missing.
+4. Check if `${CLAUDE_PLUGIN_ROOT}/rules/` exists. If so, add it as the lowest-precedence layer.
 
 If only one source exists, use flat mode (single layer). If multiple sources exist, use layered mode with precedence as described.
 
@@ -42,7 +56,7 @@ If only one source exists, use flat mode (single layer). If multiple sources exi
 
 Walk layers in order (highest precedence first). In flat mode, there is only one layer.
 
-1. In each layer directory, find all `.md` files (excluding `rules.md`, which is documentation, not a rule).
+1. In each layer directory, find all `.md` files (exclude `rules.md` — that is documentation, not a rule).
 2. Read YAML frontmatter (between `---` delimiters) from each file.
 3. Build a resolution map keyed by filename:
    - First occurrence of a filename → add it (path, keywords, title).
@@ -78,9 +92,9 @@ If a `scope:<value>` modifier is present in $ARGUMENTS, apply it as a post-filte
 - `scope` equals `always`, OR
 - no `scope` field is present (defaults to `all`)
 
-Rules with `scope: feature` are excluded when `scope:bootstrap` is requested, and vice versa. Rules with `scope: always` are never excluded.
+Exclude rules with `scope: feature` when `scope:bootstrap` is requested, and vice versa. Do not exclude rules with `scope: always`.
 
-If no `scope` modifier is present, skip this filter — return all mode-matched rules regardless of scope. This preserves backward compatibility.
+If no `scope` modifier is present, skip this filter — return all mode-matched rules regardless of scope.
 
 ## Output
 


### PR DESCRIPTION
## Summary
- Add execution contract preamble and mode-specific Task Progress checklists to all 6 skills, following Anthropic's documented checklist pattern for complex workflows
- Rewrite all instructions in imperative low-freedom style for fragile, sequence-critical workflows
- Add inline `**Constraint:**` lines at point-of-use (before codebase scan, create mode, etc.) to reinforce critical rules where violations would occur
- Standardize resolve-rules fallback language: "Rule resolution unavailable — continuing without rules" (bootstrap exception: stop)
- Decompose compound steps into atomic sub-items (plan step 1 → 1/1a-1e, design steps 4-7)
- Bump version to 2.0.0 — major because skill instruction format changed

## Context
Research found that Claude was skipping procedural steps in skill execution. The [official skill authoring best practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices) recommend the checklist pattern: "For particularly complex workflows, provide a checklist that Claude can copy into its response and check off as it progresses."

## Test plan
- [ ] Run `/dl:research` in a fresh session — verify Claude copies the checklist and checks items off
- [ ] Run `/dl:plan` → `/dl:design` → `/dl:implement` — verify checklists appear in each phase
- [ ] Verify gate checks (ls verification) are executed before wrap-up
- [ ] Verify inline constraints appear in Claude's output when processing relevant sections
- [ ] Test refine modes for plan and design — verify shorter checklists are used

🤖 Generated with [Claude Code](https://claude.com/claude-code)