### PR TITLE
Apply step-consistency patterns to all skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "dl",
       "description": "Structured development workflow for Claude Code — research, plan, design, implement",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "source": "./plugins/dl"
     }
   ]

--- a/plugins/dl/.claude-plugin/plugin.json
+++ b/plugins/dl/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dl",
   "description": "Structured development workflow for Claude Code — research, plan, design, implement",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "author": {
     "name": "minusblindfold"
   },

--- a/plugins/dl/skills/bootstrap/SKILL.md
+++ b/plugins/dl/skills/bootstrap/SKILL.md
@@ -18,12 +18,15 @@ All artifacts are stored under `.work/` in the current project directory.
 
 ## Bootstrap mode
 
+**Constraint:** You MUST generate only the scaffold. Feature code belongs in /plan → /design → /implement.
+
 Copy this checklist and check off items as you complete them:
 
 ```
 Task Progress:
 - [ ] Run /resolve-rules mode:all scope:bootstrap
 - [ ] Verify stack rule exists
+- [ ] List resolved rules and stack rule in response
 - [ ] Parse arguments for project name and description
 - [ ] Ask for missing inputs
 - [ ] Confirm inputs with user
@@ -45,6 +48,8 @@ If no rules are resolved, stop: "No rules found. Add at least a `stack.md` to yo
 
 Look for a **Stack** rule (matched by H1 title or `stack` keyword). If no stack rule is found, stop: "No stack rule found. Bootstrap needs a stack rule to know what kind of project to generate."
 
+List all resolved rules in your response and identify which one is the stack rule before proceeding to gather inputs.
+
 ### Gather inputs
 
 1. Parse `$ARGUMENTS` for the project name (first word) and optional description (rest). If no project name, ask.
@@ -56,8 +61,6 @@ Look for a **Stack** rule (matched by H1 title or `stack` keyword). If no stack 
 4. Confirm inputs with the user before generating.
 
 ### Generate project
-
-**Constraint:** Generate only the scaffold. Feature code belongs in /plan → /design → /implement.
 
 Create all files in the **current working directory**. The directory should be empty or near-empty. If not empty, warn the user and ask to confirm.
 

--- a/plugins/dl/skills/design/SKILL.md
+++ b/plugins/dl/skills/design/SKILL.md
@@ -36,10 +36,13 @@ Copy this checklist and check off items as you complete them:
 ```
 Task Progress:
 - [ ] Read plan: extract name, tasks, dependencies
-- [ ] Read CLAUDE.md and scan directory
+- [ ] List extracted tasks and dependencies in response
+- [ ] Read CLAUDE.md
+- [ ] Scan project directory and .claude/skills/
 - [ ] Check for .work/bootstrap.md
 - [ ] Ask clarifying questions
-- [ ] Write design doc (Overview, Architecture, Task Specs)
+- [ ] Write Overview and Architecture
+- [ ] Write Task Specs
 - [ ] Write Mermaid diagrams to .work/designs/diagrams/
 - [ ] Write design to .work/designs/
 - [ ] Gate: verify design file and .mmd files with ls
@@ -47,16 +50,17 @@ Task Progress:
 ```
 
 1. Read the plan. Extract name, tasks, and dependencies.
-2. Read `CLAUDE.md` if present. Scan the project directory.
-   2a. Check `.claude/skills/` for available skills.
-   2b. Check for `.work/bootstrap.md` — if found, read it. Reference the bootstrapped stack as established, not proposed.
-3. Ask 2–3 clarifying questions. Wait for answers.
+2. List the extracted tasks and dependencies in your response before proceeding.
+3. Read `CLAUDE.md` if present.
+4. Scan the project directory. Check `.claude/skills/` for available skills.
+5. Check for `.work/bootstrap.md` — if found, read it. Reference the bootstrapped stack as established, not proposed.
+6. Ask 2–3 clarifying questions. Wait for answers.
    - If bootstrap context was found: skip architecture-style questions (already decided). Focus on data relationships, UI flow, edge cases.
    - If no bootstrap context: ask as normal, including architecture style if unclear.
-4. Write the Overview and Architecture sections.
-5. Choose diagrams that best illuminate the plan — see [diagrams.md](diagrams.md). A feature may warrant more than one; omit diagrams for trivial tasks. Save each as a `.mmd` file in `.work/designs/diagrams/`. List them in the doc; do not embed diagram code inline.
-6. Write a spec for each plan task: Goal, Interfaces, Implementation notes, Acceptance criteria, Tests, Dependencies. Note which rules apply by title (e.g., `**Rules:** JPA Entity Rules, Liquibase Migration Rules`). This tells `/implement` which docs to apply via `/resolve-rules` explicit mode.
-7. Write the complete design to `.work/designs/YYYY-MM-DD-<slug>-design.md`.
+7. Write the Overview and Architecture sections.
+8. Choose diagrams that best illuminate the plan — see [diagrams.md](diagrams.md). A feature may warrant more than one; omit diagrams for trivial tasks. Save each as a `.mmd` file in `.work/designs/diagrams/`. List them in the doc; do not embed diagram code inline.
+9. Write a spec for each plan task: Goal, Interfaces, Implementation notes, Acceptance criteria, Tests, Dependencies. Note which rules apply by title (e.g., `**Rules:** JPA Entity Rules, Liquibase Migration Rules`). This tells `/implement` which docs to apply via `/resolve-rules` explicit mode.
+10. Write the complete design to `.work/designs/YYYY-MM-DD-<slug>-design.md`.
 
 ### Gate
 

--- a/plugins/dl/skills/implement/SKILL.md
+++ b/plugins/dl/skills/implement/SKILL.md
@@ -27,6 +27,8 @@ If no argument: list plans and designs, match by slug. No pairs → print "Run /
 
 ## Implement mode
 
+**Constraint:** You MUST implement only the selected task. Note out-of-scope discoveries in the implementation note rather than acting on them.
+
 Copy this checklist and check off items as you complete them:
 
 ```
@@ -37,6 +39,7 @@ Task Progress:
 - [ ] Sync tasks to Claude Code task list
 - [ ] Pick task and mark in_progress
 - [ ] Run /resolve-rules for applicable rules
+- [ ] List applied rules in response
 - [ ] Read relevant files
 - [ ] Run baseline tests
 - [ ] Implement against task spec
@@ -67,9 +70,9 @@ If `/resolve-rules` is unavailable, print: "Rule resolution unavailable — cont
 
 Follow the matched rule docs when creating or modifying files that fall under their scope.
 
-### Execute
+List applied rules in your response before proceeding to read files. If no rules matched, state that explicitly.
 
-**Constraint:** Implement only the selected task. Note out-of-scope discoveries in the implementation note rather than acting on them.
+### Execute
 
 1. Read all relevant files before editing.
 2. Run relevant tests if available to establish a baseline.

--- a/plugins/dl/skills/plan/SKILL.md
+++ b/plugins/dl/skills/plan/SKILL.md
@@ -39,6 +39,7 @@ Task Progress:
 - [ ] Check for .work/bootstrap.md
 - [ ] Check .work/research/ for matching artifacts
 - [ ] Check for greenfield project
+- [ ] List gathered context in response
 - [ ] Ask clarifying questions
 - [ ] Create tasks with TaskCreate
 - [ ] Write plan to .work/plans/
@@ -47,16 +48,16 @@ Task Progress:
 ```
 
 1. Read `CLAUDE.md` if present.
-   1a. Scan project directory structure (top-level + key subdirectories).
-   1b. Check `.claude/skills/` for available skills.
-   1c. Check for `.work/bootstrap.md` — if found, read it. Note tech stack, roles, and scaffolded entities as established context.
-   1d. Check `.work/research/` for a file matching the feature slug (`*<slug>*-research.md`). If found, read it. Use `### Gaps & Recommendations` to inform clarifying questions and task decomposition.
-   1e. **Greenfield detection:** if no `CLAUDE.md`, no `.work/bootstrap.md`, and directory is empty or near-empty → run `/resolve-rules mode:all scope:bootstrap` to check for a stack rule. If stack rule found, include "Scaffold project following rules" as task 1 in the plan. If no stack rule exists, proceed normally. If `/resolve-rules` is unavailable, print: "Rule resolution unavailable — continuing without rules." Then continue.
-2. Ask 3–5 clarifying questions. Wait for answers.
+2. Scan project directory structure (top-level + key subdirectories). Check `.claude/skills/` for available skills.
+3. Check for `.work/bootstrap.md` — if found, read it. Note tech stack, roles, and scaffolded entities as established context.
+4. Check `.work/research/` for a file matching the feature slug (`*<slug>*-research.md`). If found, read it. Use `### Gaps & Recommendations` to inform clarifying questions and task decomposition.
+5. **Greenfield detection:** if no `CLAUDE.md`, no `.work/bootstrap.md`, and directory is empty or near-empty → run `/resolve-rules mode:all scope:bootstrap` to check for a stack rule. If stack rule found, include "Scaffold project following rules" as task 1 in the plan. If no stack rule exists, proceed normally. If `/resolve-rules` is unavailable, print: "Rule resolution unavailable — continuing without rules." Then continue.
+6. List what you found in your response before asking questions: bootstrap context (if any), research artifacts (if any), greenfield status, and available skills.
+7. Ask 3–5 clarifying questions. Wait for answers.
    - If bootstrap context was found: skip questions about tech stack, database, and auth approach (already decided). Focus on domain entities, business logic, scope boundaries, and constraints.
    - If no bootstrap context: ask as normal, including stack questions if the project's tech isn't clear from CLAUDE.md.
-3. Create tasks with `TaskCreate`. Make tasks small. Order by dependency.
-4. Write the plan to `.work/plans/YYYY-MM-DD-<slug>.md`.
+8. Create tasks with `TaskCreate`. Make tasks small. Order by dependency.
+9. Write the plan to `.work/plans/YYYY-MM-DD-<slug>.md`.
 
 ### Gate
 
@@ -73,16 +74,18 @@ Copy this checklist and check off items as you complete them:
 ```
 Task Progress:
 - [ ] Check .work/research/ for new artifacts
+- [ ] List new research findings in response
 - [ ] Show current plan
 - [ ] Ask what to change — iterate until confirmed
 - [ ] Write updated plan file
 - [ ] Gate: verify plan file with ls
 ```
 
-1. Check `.work/research/` for matching research artifacts (new research may exist since the original plan). If found, note relevant findings.
-2. Show the current plan.
-3. Ask "What would you like to change?" Iterate until confirmed.
-4. Write the updated file once.
+1. Check `.work/research/` for matching research artifacts. If found, note relevant findings.
+2. List any new research findings in your response before showing the plan.
+3. Show the current plan.
+4. Ask "What would you like to change?" Iterate until confirmed.
+5. Write the updated file once.
 
 ### Gate
 


### PR DESCRIPTION
## Summary

- Flatten sub-step nesting (1a-1e, 2a/2b) in plan and design skill prose so the checklist is the single source of step sequencing
- Add "show your work" verification directives to plan (create + refine), design, implement, and bootstrap skills
- Move constraints before checklists with MUST emphasis in implement and bootstrap skills
- Bump version to 2.5.0

Follows the same patterns proven in #11 (research skill consistency).

## Test plan

- [x] Run `/dl:plan <topic>` — verify "List gathered context in response" item appears and is checked off
- [x] Run `/dl:plan refine` — verify "List new research findings in response" item appears
- [x] Run `/dl:design <slug>` — verify "List extracted tasks and dependencies" item appears
- [x] Run `/dl:implement` — verify "List applied rules in response" item appears
- [x] Run `/dl:bootstrap` (with rules configured) — verify "List resolved rules and stack rule" item appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)