### PR TITLE
Add scope: always to ecosystem rule, fix diagram naming

### DIFF
--- a/devloop/rules/ecosystem.md
+++ b/devloop/rules/ecosystem.md
@@ -1,6 +1,7 @@
 ---
 keywords: [ecosystem, integration, devenv, devloop-rules, companion, tooling]
 repos: [~/Documents/personal/devenv, ~/Documents/personal/devloop-rules]
+scope: always
 ---
 # Devloop Ecosystem
 

--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -57,7 +57,7 @@ Slugs are how skills find related artifacts. When you run `/dl:design`, it match
 └── diagrams/
     ├── 2026-03-11-user-auth-arch.mmd        # High-level architecture
     ├── 2026-03-11-user-auth-flow.mmd        # Data flow
-    ├── 2026-03-11-user-auth-component.mmd   # Internal component structure
+    ├── 2026-03-11-user-auth-component.mmd   # Component design
     └── 2026-03-11-user-auth-sequence.mmd    # Step-by-step interactions
 ```
 


### PR DESCRIPTION
## Summary
- Add `scope: always` to `devloop/rules/ecosystem.md` so linked repos are included in every skill invocation regardless of keyword matching
- Standardize diagram type comment in `docs/artifacts.md` to "Component design" (matches canonical name in `diagrams.md`)

## Test plan
- [x] Run `/dl:research` on any topic and verify ecosystem rule + linked repos are resolved
- [x] Verify `docs/artifacts.md` diagram comments are consistent with `diagrams.md` headings