### PR TITLE
Remove unused bootstrap.md check from research skill

### DIFF
--- a/plugins/dl/skills/research/SKILL.md
+++ b/plugins/dl/skills/research/SKILL.md
@@ -42,7 +42,6 @@ Task Progress:
 - [ ] List matched rules in response
 - [ ] Read CLAUDE.md
 - [ ] Scan project directory structure
-- [ ] Check for .work/bootstrap.md
 - [ ] Scan linked repos (if declared)
 - [ ] Search code for topic-relevant patterns
 - [ ] List discovered patterns in response


### PR DESCRIPTION
## Summary
- Remove the `Check for .work/bootstrap.md` step from the research skill's create mode checklist
- Research doesn't ask clarifying questions, so bootstrap context has no effect on its behavior
- Plan and design retain the check where it drives question optimization

## Test plan
- [x] Run `/dl:research` and verify the checklist no longer includes the bootstrap.md step
- [x] Verify `/dl:plan` and `/dl:design` still check for bootstrap.md