### PR TITLE
Add brainstorm skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,8 +6,8 @@
   "plugins": [
     {
       "name": "dl",
-      "description": "Structured development workflow for Claude Code — research, plan, design, implement",
-      "version": "2.6.0",
+      "description": "Structured development workflow for Claude Code — brainstorm, research, plan, design, implement",
+      "version": "2.7.0",
       "source": "./plugins/dl"
     }
   ]

--- a/README.md
+++ b/README.md
@@ -1,16 +1,17 @@
 # devloop
 
-A Claude Code plugin that structures AI-assisted development into phases. Without structure, coding agents generate inconsistent patterns and one-shot attempts that miss edge cases. devloop fixes this by breaking work into research, planning, design, and implementation — each phase produces an artifact the next one reads. No step touches code until `/dl:implement`.
+A Claude Code plugin that structures AI-assisted development into phases. Without structure, coding agents generate inconsistent patterns and one-shot attempts that miss edge cases. devloop fixes this by breaking work into brainstorming, research, planning, design, and implementation — each phase produces an artifact the next one reads. No step touches code until `/dl:implement`.
 
 ## The loop
 
 ```
-    /dl:research  →  /dl:plan  →  /dl:design  →  /dl:implement
-         ↑               ↑             ↑               │
-         └───────────────┴─────────────┴───────────────┘
-              re-enter research when discoveries surface
+    /dl:brainstorm  →  /dl:research  →  /dl:plan  →  /dl:design  →  /dl:implement
+                            ↑               ↑             ↑               │
+                            └───────────────┴─────────────┴───────────────┘
+                                 re-enter research when discoveries surface
 ```
 
+- **brainstorm** — iterative questioning to refine a feature idea, producing a decision log
 - **research** — scan rules and codebase for context, surface gaps and recommendations
 - **plan** — ask clarifying questions, produce an ordered task list
 - **design** — generate architecture, Mermaid diagrams, and a detailed spec for each task
@@ -40,6 +41,7 @@ Use `/reload-plugins` after making changes during development.
 
 | Skill | What it does |
 |-------|-------------|
+| `/dl:brainstorm` | Iterative questioning to refine a feature idea. Produces a decision log for research and planning. |
 | `/dl:research` | Scan rules and codebase for context. Re-enter at any stage to capture new findings. |
 | `/dl:plan` | Ask clarifying questions, create an ordered task list. Detects greenfield projects. |
 | `/dl:design` | Generate architecture, Mermaid diagrams, and per-task specs with acceptance criteria. |
@@ -102,6 +104,7 @@ Skills read and write artifacts to `.work/` in the current project directory:
 
 ```
 .work/
+├── brainstorms/     # Feature brainstorm decision logs
 ├── research/        # Research artifacts
 ├── plans/           # Task lists
 ├── designs/         # Design docs + diagrams/
@@ -114,7 +117,7 @@ Add `.work/` to your `.gitignore`.
 
 ## Terminal companion tools
 
-For terminal-based artifact browsing (`view-plan`, `view-design`, `view-research`, `view-implement`, `open-diagrams`, `claude-context`), see [devenv](https://github.com/minusblindfold/devenv). These are optional CLI tools that complement the plugin.
+For terminal-based artifact browsing (`view-brainstorm`, `view-plan`, `view-design`, `view-research`, `view-implement`, `open-diagrams`, `claude-context`), see [devenv](https://github.com/minusblindfold/devenv). These are optional CLI tools that complement the plugin.
 
 ## License
 

--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -6,6 +6,7 @@ Skills communicate through files in `.work/`. Each phase reads the previous phas
 
 ```
 .work/
+├── brainstorms/        # Feature brainstorm decision logs
 ├── research/           # Context scans
 ├── plans/              # Ordered task lists
 ├── designs/            # Architecture docs and specs
@@ -19,6 +20,7 @@ Skills communicate through files in `.work/`. Each phase reads the previous phas
 Artifacts follow the pattern `YYYY-MM-DD-<slug>-<type>.md`:
 
 ```
+2026-03-11-user-auth-brainstorm.md
 2026-03-11-user-auth-research.md
 2026-03-11-user-auth.md              (plan — no type suffix)
 2026-03-11-user-auth-design.md
@@ -27,23 +29,26 @@ Artifacts follow the pattern `YYYY-MM-DD-<slug>-<type>.md`:
 
 - **Date prefix** — keeps artifacts sortable by when they were created
 - **Slug** — a short identifier for the feature, consistent across all phases
-- **Type suffix** — identifies the phase (`research`, `design`, `task-N`); plans omit the suffix
+- **Type suffix** — identifies the phase (`brainstorm`, `research`, `design`, `task-N`); plans omit the suffix
 
 Slugs are how skills find related artifacts. When you run `/dl:design`, it matches the slug from your plan to locate the right file.
 
 ## How artifacts chain
 
 ```
-/dl:research → .work/research/<slug>-research.md
-                    ↓ (optional — feeds context)
-/dl:plan     → .work/plans/<slug>.md
-                    ↓ (required — feeds task list)
-/dl:design   → .work/designs/<slug>-design.md + diagrams/<slug>-*.mmd
-                    ↓ (required — feeds specs)
-/dl:implement → .work/implementations/<slug>-task-N.md + code changes
+/dl:brainstorm → .work/brainstorms/<slug>-brainstorm.md
+                      ↓ (optional — feeds context)
+/dl:research   → .work/research/<slug>-research.md
+                      ↓ (optional — feeds context)
+/dl:plan       → .work/plans/<slug>.md
+                      ↓ (required — feeds task list)
+/dl:design     → .work/designs/<slug>-design.md + diagrams/<slug>-*.mmd
+                      ↓ (required — feeds specs)
+/dl:implement  → .work/implementations/<slug>-task-N.md + code changes
 ```
 
-- `/dl:plan` reads research artifacts if they exist for the feature. The gaps and recommendations inform the clarifying questions and task ordering.
+- If brainstorm artifacts exist for the topic, `/dl:research` reads them to avoid repeating codebase scans already captured in the brainstorm.
+- `/dl:plan` reads brainstorm and research artifacts if they exist for the feature. Decisions from brainstorming and gaps from research inform the clarifying questions and task ordering.
 - `/dl:design` requires a plan. It reads the task list and produces a spec for each task, including goal, interfaces, acceptance criteria, and applicable rules.
 - `/dl:implement` requires a plan and design. It loads both, displays task completion status, and implements one task at a time against the spec.
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -7,13 +7,30 @@ Each step produces an artifact that the next step reads. No step touches code un
 ## The loop
 
 ```
-    /dl:research  →  /dl:plan  →  /dl:design  →  /dl:implement
-         ↑               ↑             ↑               │
-         └───────────────┴─────────────┴───────────────┘
-              re-enter research when discoveries surface
+    /dl:brainstorm  →  /dl:research  →  /dl:plan  →  /dl:design  →  /dl:implement
+                            ↑               ↑             ↑               │
+                            └───────────────┴─────────────┴───────────────┘
+                                 re-enter research when discoveries surface
 ```
 
 During any phase, run `/dl:research` to feed discoveries back into plans and designs.
+
+## /dl:brainstorm
+
+```
+/dl:brainstorm "topic"
+```
+
+Iterative questioning session that probes a feature idea. Claude resolves rules, scans the codebase, and asks rounds of questions — each with a recommended answer you can accept, reject, or refine. The conversation continues until you signal you're done or the decision space converges.
+
+The output is a decision log (not a transcript) saved to `.work/brainstorms/`. Run `/dl:research` afterward to do a deep codebase scan informed by your decisions.
+
+Brainstorm is optional — skip it if you already know what you want to build. After brainstorming, your context may be full of conversation. Use `/rewind` to reset, then run `/dl:research` — the brainstorm artifact carries your decisions forward.
+
+```
+/dl:brainstorm                  # ask what to brainstorm
+/dl:brainstorm <slug>           # reopen an existing brainstorm
+```
 
 ## /dl:research
 
@@ -35,7 +52,7 @@ Research artifacts are saved to `.work/research/`.
 
 Claude asks clarifying questions (scope, constraints, entities), then produces a task list ordered by dependency. The plan is saved to `.work/plans/`.
 
-If research artifacts exist for the feature, `/dl:plan` reads them automatically — the gaps and recommendations inform the questions and tasks. In a greenfield project (no existing structure), `/dl:plan` detects this and suggests scaffolding as the first task.
+If brainstorm or research artifacts exist for the feature, `/dl:plan` reads them automatically — decisions from brainstorming and gaps from research inform the questions and tasks. In a greenfield project (no existing structure), `/dl:plan` detects this and suggests scaffolding as the first task.
 
 Push back. Reorder tasks, split or merge them, add constraints. Claude won't touch code.
 
@@ -95,7 +112,7 @@ If you've corrected Claude multiple times on the same issue, the context can bec
 
 - **Start small.** Don't plan 15 tasks. Start with 3-5. You can always `/dl:plan refine` to add more.
 - **Let Claude interview you.** Give a short description and let Claude ask the clarifying questions. They often surface constraints you hadn't considered.
-- **Review artifacts, not just code.** Check `.work/plans/`, `.work/designs/`, and `.work/implementations/` between sessions. The artifacts capture decisions and rationale that git commits don't.
+- **Review artifacts, not just code.** Check `.work/brainstorms/`, `.work/plans/`, `.work/designs/`, and `.work/implementations/` between sessions. The artifacts capture decisions and rationale that git commits don't.
 - **One task at a time.** `/dl:implement` works on a single task per invocation. This keeps context focused and changes reviewable.
 - **Commit after each task.** Small, well-described commits make review and rollback easy.
 - **Use /dl:research as a re-entry point.** Discovered something unexpected? Run `/dl:research` to capture it, then refine the plan or design. The workflow is a loop, not a line.

--- a/plugins/dl/.claude-plugin/plugin.json
+++ b/plugins/dl/.claude-plugin/plugin.json
@@ -1,14 +1,14 @@
 {
   "name": "dl",
-  "description": "Structured development workflow for Claude Code — research, plan, design, implement",
-  "version": "2.6.0",
+  "description": "Structured development workflow for Claude Code — brainstorm, research, plan, design, implement",
+  "version": "2.7.0",
   "author": {
     "name": "minusblindfold"
   },
   "homepage": "https://github.com/minusblindfold/devloop",
   "repository": "https://github.com/minusblindfold/devloop",
   "license": "MIT",
-  "keywords": ["workflow", "planning", "design", "implementation", "skills"],
+  "keywords": ["workflow", "brainstorm", "planning", "design", "implementation", "skills"],
   "hooks": {
     "PreToolUse": [
       {

--- a/plugins/dl/skills/brainstorm/SKILL.md
+++ b/plugins/dl/skills/brainstorm/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: brainstorm
+description: Iterative questioning to refine a feature idea before research and planning. Use when the user wants to brainstorm, explore an idea, or probe a feature concept.
+argument-hint: "[feature or topic]"
+allowed-tools: Read Bash Glob Grep
+---
+
+Execute each section below in order. Do not skip sections.
+
+1. Determine your mode.
+2. Copy the **Task Progress** checklist from that mode's section into your response.
+3. Work through each item. Check it off as you complete it.
+4. Do not proceed past a **Gate** until the gate condition is verified.
+
+## Artifact — required output
+
+Write the artifact to `.work/brainstorms/`. Save the artifact before proceeding to wrap up. Do not summarize or suggest next steps until the artifact file has been written and verified with `ls`.
+
+## Config
+
+All artifacts are stored under `.work/` in the current project directory.
+
+## Mode
+
+Parse `$ARGUMENTS`:
+
+- Matches an existing file in `.work/brainstorms/` by slug → **re-entry** (reopen conversation from prior decisions).
+- Set but no match → **create** new brainstorm.
+- Empty → ask the user what they would like to brainstorm. Wait for a topic, then proceed in **create** mode.
+
+## Create mode
+
+**Constraint:** You MUST NOT modify project files. This skill produces context, not code.
+
+Copy this checklist and check off items as you complete them:
+
+```
+Task Progress:
+- [ ] Determine mode (create / re-entry)
+- [ ] Run /resolve-rules
+- [ ] List matched rules in response
+- [ ] Read CLAUDE.md
+- [ ] Scan project directory structure
+- [ ] Scan linked repos (if declared)
+- [ ] Search code for topic-relevant patterns
+- [ ] List gathered context in response
+- [ ] Begin iterative questioning
+- [ ] Write artifact to .work/brainstorms/
+- [ ] Gate: verify artifact with ls
+- [ ] Wrap up: suggest /dl:research
+```
+
+### Context gathering
+
+1. Run `/resolve-rules`:
+   - Topic provided → `mode:keyword <topic>`.
+   - If `/resolve-rules` is unavailable, print: "Rule resolution unavailable — continuing without rules." Then continue.
+   - For each matched rule, extract title (H1 heading), source layer path, and first 3–5 key patterns.
+   - List matched rules in your response before proceeding.
+
+2. Read `CLAUDE.md` if present.
+
+3. Scan the project directory structure (top-level + key subdirectories).
+
+4. If `/resolve-rules` output included "Linked repos", scan each declared repo:
+   - Expand `~` and verify the directory exists. If not, print a warning and skip.
+   - Read `CLAUDE.md` (or `README.md` if no CLAUDE.md).
+   - Scan the top-level directory structure with `ls`.
+   - Grep for topic-relevant patterns. Limit to the top 10–15 matches.
+
+5. Search the project codebase for patterns relevant to the topic. Look for existing implementations, naming patterns, tech choices, and anything that might shape the feature. This is the same depth as `/research`.
+
+6. List what you found: matched rules, codebase patterns, linked repo context. This grounds the conversation in project reality.
+
+### Iterative questioning
+
+Ask questions in rounds. Each round builds on prior answers.
+
+**Per round:**
+- Ask 2–4 questions about the feature.
+- Each question MUST include a **recommended answer** based on what you found in the codebase, rules, and prior answers. The user refines your recommendation rather than starting from zero.
+- Questions should probe: scope boundaries, trade-offs, edge cases, interactions with existing systems, user expectations, alternative approaches.
+- Wait for the user to respond.
+
+**Between rounds:**
+- Assess whether there are more branches to explore.
+- If the user signals they are done (e.g., "done", "that's enough", "let's move on") → wrap up.
+- If 3 or more rounds have passed and the decision space feels resolved, propose wrapping up: "I think we've covered the key decisions. Ready to wrap up, or is there more to explore?"
+- If more to explore → ask the next round.
+
+### Output
+
+Write to `.work/brainstorms/YYYY-MM-DD-<slug>-brainstorm.md`:
+
+```markdown
+# <Topic> Brainstorm
+
+## Context
+
+### Matched Rules
+
+| Rule | Source | Key Patterns |
+|---|---|---|
+| Title from H1 | file path | first 3-5 patterns |
+
+### Codebase Patterns
+
+- **Pattern:** <what was found>
+- **Location:** <where>
+- **Notes:** <consistency, alternatives, concerns>
+
+## Decisions
+
+- **<Decision area>:** <what was decided>
+  - **Rationale:** <why>
+  - **Alternatives considered:** <what else was discussed>
+
+## Open Questions
+
+- <things not yet resolved>
+
+## Constraints Discovered
+
+- <hard constraints surfaced during brainstorming>
+```
+
+Capture decisions and rationale, not a transcript of the conversation.
+
+### Gate
+
+Run `ls` on the saved file path. If the file does not exist, write it now. Do not proceed to wrap up until the file is confirmed on disk.
+
+### Wrap up
+
+1. Summarize: decisions made, open questions remaining, constraints discovered.
+2. Suggest next step: `/dl:research <slug>` to do a deep codebase scan informed by these decisions.
+
+## Re-entry mode
+
+**Constraint:** You MUST NOT modify project files. This skill produces context, not code.
+
+Copy this checklist and check off items as you complete them:
+
+```
+Task Progress:
+- [ ] Read existing brainstorm artifact
+- [ ] Run /resolve-rules
+- [ ] Scan codebase for new patterns
+- [ ] Present prior decisions summary
+- [ ] Resume iterative questioning
+- [ ] Update artifact
+- [ ] Gate: verify artifact with ls
+- [ ] Wrap up: suggest /dl:research
+```
+
+1. Read the existing brainstorm artifact in full.
+2. Run `/resolve-rules` as in create mode. Rules may have changed since the last session.
+3. Search the codebase for any new patterns relevant to the topic.
+4. Present a summary of prior decisions to the user: "Here's where we left off:" followed by the key decisions and any open questions. Ask: "What would you like to explore further?"
+5. Resume iterative questioning, building on prior decisions. Same round structure as create mode.
+6. On wrap-up: rewrite the artifact with updated decisions. Mark changed decisions with rationale for the change. Preserve any decisions that haven't changed.
+7. Gate: verify file with `ls`.
+
+### Gate
+
+Run `ls` on the saved file path. If the file does not exist, write it now. Do not proceed to wrap up until the file is confirmed on disk.
+
+### Wrap up
+
+1. Summarize what changed: new decisions, changed decisions, newly resolved open questions.
+2. Suggest next step: `/dl:research <slug>` to do a deep codebase scan informed by these decisions.
+
+## Rules
+
+- Do not modify project files. This skill produces context, not code.
+- Always include recommended answers with questions — do not ask bare questions.
+- Use the resolution algorithm for rule discovery — do not hardcode paths.
+- Capture decisions and rationale in the artifact, not a conversation transcript.
+- On re-entry, reopen the conversation from prior decisions — do not append a new dated section.

--- a/plugins/dl/skills/plan/SKILL.md
+++ b/plugins/dl/skills/plan/SKILL.md
@@ -37,6 +37,7 @@ Task Progress:
 - [ ] Read CLAUDE.md
 - [ ] Scan project directory and .claude/skills/
 - [ ] Check for .work/bootstrap.md
+- [ ] Check .work/brainstorms/ for matching artifacts
 - [ ] Check .work/research/ for matching artifacts
 - [ ] Scan linked repos (if declared)
 - [ ] Check for greenfield project
@@ -51,15 +52,17 @@ Task Progress:
 1. Read `CLAUDE.md` if present.
 2. Scan project directory structure (top-level + key subdirectories). Check `.claude/skills/` for available skills.
 3. Check for `.work/bootstrap.md` — if found, read it. Note tech stack, roles, and scaffolded entities as established context.
-4. Check `.work/research/` for a file matching the feature slug (`*<slug>*-research.md`). If found, read it. Use `### Gaps & Recommendations` to inform clarifying questions and task decomposition.
-5. **Linked repo context:** If the research artifact from step 4 contains a `### Linked Repo Context` section, note it — print "Linked repo context found in research artifact." and include it in the gathered context listing. If no research artifact was found, run `/resolve-rules mode:keyword <feature description>` to check for linked repos. If linked repos are declared, do an orientation-only scan of each (expand `~`, verify directory exists, read `CLAUDE.md` or `README.md`, scan top-level directory with `ls`). Skip repos that don't exist locally with a warning. Do not do targeted keyword code search — that's research's job.
-6. **Greenfield detection:** if no `CLAUDE.md`, no `.work/bootstrap.md`, and directory is empty or near-empty → run `/resolve-rules mode:all scope:bootstrap` to check for a stack rule. If stack rule found, include "Scaffold project following rules" as task 1 in the plan. If no stack rule exists, proceed normally. If `/resolve-rules` is unavailable, print: "Rule resolution unavailable — continuing without rules." Then continue.
-7. List what you found in your response before asking questions: bootstrap context (if any), research artifacts (if any), linked repo context (if any), greenfield status, and available skills.
-8. Ask 3–5 clarifying questions. Wait for answers.
+4. Check `.work/brainstorms/` for a file matching the feature slug (`*<slug>*-brainstorm.md`). If found, read it. Use `## Decisions` and `## Constraints Discovered` to inform clarifying questions — skip questions already answered in the brainstorm.
+5. Check `.work/research/` for a file matching the feature slug (`*<slug>*-research.md`). If found, read it. Use `### Gaps & Recommendations` to inform clarifying questions and task decomposition.
+6. **Linked repo context:** If the research artifact from step 5 contains a `### Linked Repo Context` section, note it — print "Linked repo context found in research artifact." and include it in the gathered context listing. If no research artifact was found, run `/resolve-rules mode:keyword <feature description>` to check for linked repos. If linked repos are declared, do an orientation-only scan of each (expand `~`, verify directory exists, read `CLAUDE.md` or `README.md`, scan top-level directory with `ls`). Skip repos that don't exist locally with a warning. Do not do targeted keyword code search — that's research's job.
+7. **Greenfield detection:** if no `CLAUDE.md`, no `.work/bootstrap.md`, and directory is empty or near-empty → run `/resolve-rules mode:all scope:bootstrap` to check for a stack rule. If stack rule found, include "Scaffold project following rules" as task 1 in the plan. If no stack rule exists, proceed normally. If `/resolve-rules` is unavailable, print: "Rule resolution unavailable — continuing without rules." Then continue.
+8. List what you found in your response before asking questions: bootstrap context (if any), brainstorm artifacts (if any), research artifacts (if any), linked repo context (if any), greenfield status, and available skills.
+9. Ask 3–5 clarifying questions. Wait for answers.
+   - If brainstorm context was found: skip questions already decided in the brainstorm. Focus on implementation-specific questions not covered by the brainstorm.
    - If bootstrap context was found: skip questions about tech stack, database, and auth approach (already decided). Focus on domain entities, business logic, scope boundaries, and constraints.
    - If no bootstrap context: ask as normal, including stack questions if the project's tech isn't clear from CLAUDE.md.
-9. Create tasks with `TaskCreate`. Make tasks small. Order by dependency.
-10. Write the plan to `.work/plans/YYYY-MM-DD-<slug>.md`.
+10. Create tasks with `TaskCreate`. Make tasks small. Order by dependency.
+11. Write the plan to `.work/plans/YYYY-MM-DD-<slug>.md`.
 
 ### Gate
 
@@ -75,16 +78,16 @@ Copy this checklist and check off items as you complete them:
 
 ```
 Task Progress:
-- [ ] Check .work/research/ for new artifacts
-- [ ] List new research findings in response
+- [ ] Check .work/brainstorms/ and .work/research/ for new artifacts
+- [ ] List new findings in response
 - [ ] Show current plan
 - [ ] Ask what to change — iterate until confirmed
 - [ ] Write updated plan file
 - [ ] Gate: verify plan file with ls
 ```
 
-1. Check `.work/research/` for matching research artifacts. If found, note relevant findings.
-2. List any new research findings in your response before showing the plan.
+1. Check `.work/brainstorms/` and `.work/research/` for matching artifacts. If found, note relevant findings.
+2. List any new findings in your response before showing the plan.
 3. Show the current plan.
 4. Ask "What would you like to change?" Iterate until confirmed.
 5. Write the updated file once.


### PR DESCRIPTION
## Summary

- New `/dl:brainstorm` skill — iterative questioning with recommended answers, producing a decision log artifact in `.work/brainstorms/`
- Updated artifact chain: brainstorm → research → plan → design → implement (brainstorm is optional)
- `/dl:plan` now reads brainstorm artifacts to skip already-answered clarifying questions
- Updated workflow docs, README, artifacts docs, plugin.json
- Version bump to 2.7.0

## Test plan

- [x] Run `/dl:brainstorm test-feature` in a project and verify multi-round questioning works
- [x] Verify artifact is written to `.work/brainstorms/` with correct format
- [x] Run `/dl:brainstorm <existing-slug>` to test re-entry mode
- [x] Run `/dl:plan` after brainstorm and verify it reads brainstorm context
- [x] Verify version is 2.7.0 in both plugin.json and marketplace.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)