### PR TITLE
Enforce vertical slicing across plan, design, and research

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "dl",
       "description": "Structured development workflow for Claude Code — brainstorm, research, plan, design, implement, review",
-      "version": "2.11.0",
+      "version": "2.12.0",
       "source": "./plugins/dl"
     }
   ]

--- a/plugins/dl/.claude-plugin/plugin.json
+++ b/plugins/dl/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dl",
   "description": "Structured development workflow for Claude Code — brainstorm, research, plan, design, implement, review",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "author": {
     "name": "minusblindfold"
   },

--- a/plugins/dl/rules/skill-authoring.md
+++ b/plugins/dl/rules/skill-authoring.md
@@ -1,0 +1,50 @@
+---
+keywords: [skill, skills, SKILL.md, instruction, prompt, workflow, plugin]
+scope: always
+---
+# Skill Authoring Rules
+
+> Principles for writing and modifying devloop skill files, derived from the QRISPY analysis.
+
+## Instruction budget
+
+- Each skill file must stay under 40 imperative instructions. Models follow ~150-200 instructions consistently across an entire session; skills share that budget with CLAUDE.md, system prompt, tools, and MCP overhead.
+- Count actual imperative sentences, not lines. A template in a code block counts as 1 instruction total, not per-heading.
+- If a skill is over budget, cut structural and template instructions first. Never cut behavioral instructions — these are the ones that affect output quality (collaborative exploration, two-pass review, task isolation, deviation tracking).
+
+## Compression patterns
+
+When reducing instruction count, apply these in order of ROI:
+
+1. **Merge create/re-entry checklists** — One checklist with conditional branches ("If re-entry: read existing artifact. If new: gather context.") replaces two separate checklists. Saves 4-8 instructions.
+2. **Consolidate gate instructions** — Multi-step gates ("verify artifact exists; write if missing; update marker stage; update marker date") become a single compound instruction.
+3. **Simplify artifact templates** — Strip field descriptions from templates. Section headings alone are sufficient — models know what `## Decisions` means.
+
+## Structural vs behavioral
+
+- **Behavioral instructions** affect output quality. Examples: how brainstorm explores ideas, how review separates concerns into two passes, how implement tracks deviations. Preserve these.
+- **Structural instructions** are checklists, gates, markers, wrap-ups. These are the primary cut target when a skill is over budget.
+- **Template instructions** are artifact format specs. Secondary cut target — headings alone carry meaning.
+
+## Artifact chaining
+
+- Each skill produces a markdown artifact that becomes the next skill's input. This is the core reliability mechanism — static artifacts survive context compaction.
+- Never break the chain: brainstorm -> research -> plan -> design -> implement -> review.
+- Hard dependencies must be enforced with gate checks (e.g., implement refuses to start without a design file).
+
+## Vertical slicing
+
+- Plan tasks must be vertically sliced — each task delivers a testable end-to-end slice through the stack, not a horizontal layer.
+- Prohibit standalone "create all models" or "set up database schema" tasks. Each task should touch all relevant layers.
+- Each task should include a test expectation, not a separate "add tests" task at the end.
+
+## Separation of concerns
+
+- Research produces facts, not opinions. When research knows what's being built, it injects implementation opinions into what should be objective findings.
+- Brainstorm owns decisions. Research queries come from brainstorm to keep research targeted.
+- Design is the primary review checkpoint. Plan gets a spot-check; design gets full review before implementation.
+
+## Review gates
+
+- Use distinct language for different gate strengths. "Spot-check" for plan (lightweight). "Primary checkpoint — must be reviewed before implementation" for design (heavyweight).
+- Don't use identical wording for gates of different importance — it flattens them to equal weight.

--- a/plugins/dl/skills/design/SKILL.md
+++ b/plugins/dl/skills/design/SKILL.md
@@ -43,7 +43,7 @@ Ask 2-3 clarifying questions. Read prior artifact decisions — only ask about g
 
 ## Task specs
 
-Write a spec for each plan task: Goal, Interfaces, Implementation notes, Acceptance criteria, Tests, Dependencies. Note applicable rules by title (e.g., `**Rules:** JPA Entity Rules`) — this tells `/implement` which docs to apply via `/resolve-rules` explicit mode.
+Write a spec for each plan task: Goal, Interfaces, Implementation notes, Acceptance criteria, Tests, Dependencies. In the Tests field, write concrete verification steps that implement can run immediately after completing the slice — not a deferred test plan. Note applicable rules by title (e.g., `**Rules:** JPA Entity Rules`) — this tells `/implement` which docs to apply via `/resolve-rules` explicit mode.
 
 ## Diagrams
 

--- a/plugins/dl/skills/plan/SKILL.md
+++ b/plugins/dl/skills/plan/SKILL.md
@@ -40,7 +40,7 @@ List what you found before asking. Ask 3-5 clarifying questions. Read decisions 
 
 ## Task creation
 
-Create tasks with `TaskCreate`. Make tasks small and vertically-sliced — each task delivers a testable end-to-end slice. Order by dependency, then by what unblocks the most follow-up work.
+Create tasks with `TaskCreate`. Decompose by user-visible behavior or capability, not by architectural layer. Do not create tasks like "set up all database models," "build the service layer," or "add tests for everything" — each task should touch all relevant layers for its slice. Order by dependency, then by what unblocks the most follow-up work.
 
 ## Refine mode
 
@@ -57,6 +57,7 @@ Check for new brainstorm/research artifacts. Show the current plan. Ask "What wo
 
 - [ ] **Task title** — what it does; key constraints or dependencies if any.
   - **Done when:** one-line acceptance criterion.
+  - **Verified by:** how to prove this slice works (test, command, or observable behavior).
 ```
 
 ## Gate
@@ -70,5 +71,5 @@ Present the plan. Suggest the user spot-check task ordering, then run `/dl:desig
 ## Rules
 
 - Do not write code. This skill produces a plan, not an implementation.
-- Right-size tasks — small and vertically-sliced over large and horizontal.
+- Do not group tasks by architectural layer — each task delivers a testable end-to-end slice.
 - In refine mode, write once at the end.

--- a/plugins/dl/skills/research/SKILL.md
+++ b/plugins/dl/skills/research/SKILL.md
@@ -35,7 +35,7 @@ Task Progress:
 
 ## Query execution
 
-Run `/resolve-rules mode:keyword <topic>` as a subtask. For each query from the brainstorm artifact, search the codebase with targeted reads and greps. For linked repos from resolve-rules, include them in the search. Record findings per query — keep findings factual, not opinionated.
+Run `/resolve-rules mode:keyword <topic>` as a subtask. For each query from the brainstorm artifact, search the codebase with targeted reads and greps. For linked repos from resolve-rules, include them in the search. Record findings per query — keep findings factual, not opinionated. When a query touches an existing feature, note how it's structured through the stack (e.g., route → service → model → test) — this gives plan concrete examples for vertical slicing.
 
 ## Synthesis
 


### PR DESCRIPTION
## Summary

- **Plan:** Add explicit anti-patterns against horizontal decomposition ("do not create tasks like 'set up all database models'"), decompose-by-behavior guidance, and `Verified by:` line in plan format template
- **Design:** Add per-slice test instruction — Tests field must contain concrete verification steps implement can run immediately
- **Research:** Add end-to-end feature structure discovery — note how existing features are layered through the stack to give plan concrete vertical slice examples
- **Rules:** Add `skill-authoring.md` rule file capturing QRISPY findings (instruction budget, compression patterns, behavioral vs structural, vertical slicing principles)
- **Version:** 2.11.0 → 2.12.0

## Test plan

- [ ] Run `/dl:plan` against a multi-layer feature idea and verify tasks decompose by behavior, not by architectural layer
- [ ] Verify each plan task includes a `Verified by:` line
- [ ] Run `/dl:design` and verify each task spec's Tests field has concrete, runnable verification steps
- [ ] Run `/dl:research` on a feature touching existing code and verify findings include end-to-end structure notes
- [ ] Verify all skill files stay under 40-instruction budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)