### PR TITLE
implement-all: foreman/worker split and `all` mode for /dl:implement

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "dl",
       "description": "Structured development workflow for Claude Code — brainstorm, research, plan, design, implement, review",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "source": "./plugins/dl"
     }
   ]

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A Claude Code plugin that structures AI-assisted development into phases. Withou
 - **research** — execute research queries from brainstorm as targeted codebase searches
 - **plan** — ask clarifying questions, produce an ordered task list
 - **design** — generate architecture, Mermaid diagrams, and a detailed spec for each task
-- **implement** — implement one task at a time against the spec, track completion
+- **implement** — delegate each task to a fresh-context worker subagent, one task per run or `all` for the whole plan, track completion
 - **review** — load rules and design context, review code for rule violations and security issues
 
 Start with `/dl:brainstorm` — it sizes the work and routes it: **small** changes get a mini-spec and go straight to `/dl:implement`; **medium** work skips research and goes to `/dl:plan`; **large** features run the full pipeline with design review as the mandatory checkpoint. `/dl:research` can re-enter at any stage when discoveries surface during implementation.
@@ -47,14 +47,14 @@ Use `/reload-plugins` after making changes during development.
 | `/dl:research` | Execute research queries from brainstorm as targeted codebase searches, or research a topic directly. Runs in a forked subagent — scan noise stays out of your session. |
 | `/dl:plan` | Ask clarifying questions, create a vertically-sliced task list. Detects greenfield projects. |
 | `/dl:design` | Primary review checkpoint. Generate architecture, Mermaid diagrams, and per-task specs. |
-| `/dl:implement` | Implement one task at a time against the spec. Tracks progress across sessions. |
+| `/dl:implement` | Implement tasks against the spec. Each task runs in a fresh-context worker subagent; run a single task, or `all` to work through every unchecked task with a commit per task and an automatic review at the end. Tracks progress across sessions. |
 | `/dl:review` | Load rules and design context, review code for rule violations and security issues. Works standalone or after `/dl:implement`. Runs in a forked subagent; archives the feature marker on completion. |
-`/dl:plan` and `/dl:design` support refine mode — invoke with no args when existing artifacts are found.
+`/dl:plan` and `/dl:design` support refine mode — invoke with no args when existing artifacts are found. `/dl:implement all` requires Claude Code ≥ 2.1.172 (nested subagent spawning).
 
 ## What you get
 
 - **Architecture diagrams** — `/dl:design` generates Mermaid diagrams (architecture, data flow, component, sequence) saved as `.mmd` files in `.work/designs/diagrams/`.
-- **Cross-session tracking** — Task completion lives as checkboxes in the plan artifact itself. Run `/dl:implement` in a new session and pick up where you left off.
+- **Cross-session tracking** — Task completion lives as checkboxes in the plan artifact itself. Run `/dl:implement` in a new session and pick up where you left off — including resuming an `all` run that halted partway: re-running starts at the first unchecked task.
 - **Refine mode** — Run `/dl:plan` or `/dl:design` with no args to iterate on existing artifacts.
 - **Greenfield detection** — In a new project with no existing structure, `/dl:plan` suggests scaffolding as the first task.
 - **Active feature tracking** — Skills auto-detect the active feature via `.work/active/<slug>.md` markers. Start a brainstorm or plan, and every downstream skill auto-selects it — no re-specifying slugs. Supports multiple concurrent features for multi-agent workflows.

--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -70,7 +70,7 @@ Slugs are how skills find related artifacts. When you run `/dl:design`, it match
 - `/dl:research` executes the brainstorm's Research Queries section as targeted codebase searches rather than broad scans; without a brainstorm artifact it derives queries from the topic.
 - `/dl:plan` reads brainstorm and research artifacts. Decisions from brainstorming and gaps from research inform clarifying questions and task ordering. Tasks are vertically-sliced.
 - `/dl:design` requires a plan. It produces a spec for each task and is the primary review checkpoint — reviewed thoroughly before implementation.
-- `/dl:implement` requires a plan and design (or a mini-spec for small work). It implements one task at a time against the spec.
+- `/dl:implement` requires a plan and design (or a mini-spec for small work). It delegates each task to a fresh-context worker subagent — a single task per invocation, or `all` to run every unchecked task in order.
 - `/dl:review` is optional. It reviews changes for rule violations and security issues. Works standalone or after `/dl:implement`.
 
 ## Diagrams

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -84,10 +84,16 @@ The design is the primary review checkpoint — review it thoroughly before impl
 ## /dl:implement
 
 ```
-/dl:implement
+/dl:implement                   # pick a task
+/dl:implement <slug> <N>        # implement task N
+/dl:implement <slug> all        # run every unchecked task in order
 ```
 
-Claude loads the plan and design, displays the task list with completion status, and implements one task at a time. It reads relevant files first, checks which rules apply, runs existing tests to establish a baseline, implements against the spec, and re-runs tests. An implementation note is saved to `.work/implementations/`.
+Claude acts as a foreman: it loads the plan and design, displays the task list with completion status, and delegates the selected task to a fresh-context worker subagent. The worker receives a payload — the task entry, its design spec, applicable rules, and prior implementation notes — then reads the relevant files, runs existing tests to establish a baseline, implements against the spec, and re-runs tests. An implementation note is saved to `.work/implementations/`, and the foreman verifies the worker's return before checking the task off.
+
+**Single-task mode** implements one task per invocation and suggests a commit at the end.
+
+**All mode** (`all`) requires a clean working tree, then loops over every unchecked task in plan order, committing each task's changes separately as it completes. The line halts — leaving the box unchecked — when a task fails, targets a separate repo, or declares an interface-changing deviation that affects unstarted tasks; re-run `/dl:implement <slug> all` to resume from the first unchecked task. When the last task lands, it automatically runs `/dl:review` in a forked subagent and surfaces the findings without acting on them. All mode requires Claude Code ≥ 2.1.172 (nested subagent spawning).
 
 Completed tasks are checked off in the plan file itself — the artifact is the authoritative progress state, so you pick up exactly where you left off across sessions.
 
@@ -113,8 +119,8 @@ If you've corrected Claude multiple times on the same issue, the context can bec
 - **Start small.** Don't plan 15 tasks. Start with 3-5. You can always `/dl:plan refine` to add more.
 - **Let Claude interview you.** Give a short description and let Claude ask the clarifying questions. They often surface constraints you hadn't considered.
 - **Review artifacts, not just code.** Check `.work/brainstorms/`, `.work/plans/`, `.work/designs/`, and `.work/implementations/` between sessions. The artifacts capture decisions and rationale that git commits don't.
-- **One task at a time.** `/dl:implement` works on a single task per invocation. This keeps context focused and changes reviewable.
-- **Commit after each task.** Small, well-described commits make review and rollback easy.
+- **One task per worker.** Every task runs in its own fresh-context worker, whether you invoke `/dl:implement` per task or once with `all`. This keeps each task's context focused; reviewability comes from the per-task commits.
+- **Commit after each task.** Small, well-described commits make review and rollback easy. All mode does this for you.
 - **Use /dl:research as a re-entry point.** Discovered something unexpected? Run `/dl:research` to capture it, then refine the plan or design. The workflow is a loop, not a line.
 
 ## Further reading

--- a/plugins/dl/.claude-plugin/plugin.json
+++ b/plugins/dl/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dl",
   "description": "Structured development workflow for Claude Code — brainstorm, research, plan, design, implement, review",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "author": {
     "name": "minusblindfold"
   },

--- a/plugins/dl/skills/implement/SKILL.md
+++ b/plugins/dl/skills/implement/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: implement
 description: Implements tasks from a plan and design by delegating each task to a fresh-context worker subagent. Use when coding a planned feature or working through tasks one at a time.
-argument-hint: "[plan-slug] [task-number]"
+argument-hint: "[plan-slug] [task-number|all]"
 allowed-tools: Read Write Edit Bash(git:*) Agent
 ---
 
 Execute each section in order. Copy the checklist and check off items as you complete them. Do not proceed past a **Gate** until verified.
 
-**Artifact:** The worker writes an implementation note to `.work/implementations/`. Verify with `ls` before wrapping up — even if the task is incomplete.
+**Artifact:** The worker writes an implementation note to `.work/implementations/` — even if the task is incomplete.
 
 **Constraint:** You are the foreman — you do not implement tasks yourself. A fresh-context worker subagent implements the selected task; you build its payload, verify its return, and own the plan checkboxes.
 
@@ -15,19 +15,19 @@ Execute each section in order. Copy the checklist and check off items as you com
 
 Check `.work/active/` for marker files. If exactly one exists and no $ARGUMENTS provided, auto-select that feature's slug. If multiple markers exist, list them, offer to archive any with `date` older than 30 days to `.work/archive/`, then ask. Arguments always override.
 
-Parse $ARGUMENTS as `<slug>` or `<slug> <task-N>`. If the marker has `stage: mini-spec`, read the brainstorm artifact's `## Mini-Spec` section as the spec — a single task (N = 1), no plan or design required; skip task picking. Otherwise find the plan in `.work/plans/` and matching design in `.work/designs/`. Missing design → print "No design found. Run /design first." and stop. No argument → list plan/design pairs; none: stop; one: confirm; many: ask to pick.
+Parse $ARGUMENTS as `<slug>`, `<slug> <task-N>`, or `<slug> all`. If the marker has `stage: mini-spec`, read the brainstorm artifact's `## Mini-Spec` section as the spec — a single task (N = 1), no plan or design required; skip task picking. Otherwise find the plan in `.work/plans/` and matching design in `.work/designs/`. Missing design → print "No design found. Run /design first." and stop. No argument → list plan/design pairs; none: stop; one: confirm; many: ask to pick.
 
 ```
 Task Progress:
 - [ ] Find plan and design by slug
 - [ ] Read plan and design; read completion state from the plan's checkboxes
-- [ ] Pick task (from args or ask)
+- [ ] Pick task from args or ask — `all`: require clean tree, then loop per All mode
 - [ ] Build the worker payload (task entry, design spec, rules, prior notes)
 - [ ] Spawn the worker; receive its structured return
 - [ ] Verify: note exists, STATUS complete, tests pass
-- [ ] Check off the task in the plan
+- [ ] Check off the task in the plan (all mode: commit, then next task or halt)
 - [ ] Gate: verify note with ls; update active marker
-- [ ] Wrap up: summarize worker return, note deviations, suggest commit
+- [ ] Wrap up: summarize worker return(s), note deviations, suggest commit
 ```
 
 ## Load
@@ -36,7 +36,25 @@ Read plan and design in full. The plan's `- [ ]` checkboxes are the authoritativ
 
 ## Pick task
 
-If $ARGUMENTS includes a task number, use it. Otherwise ask. Warn if dependencies are incomplete.
+If $ARGUMENTS includes a task number, use it; if it says `all`, follow All mode instead; otherwise ask, warning if dependencies are incomplete.
+
+## All mode
+
+`all` runs every unchecked task in plan order — position = task number, no dependency graph. Mini-spec features have a single task, so `all` behaves like task 1.
+
+**Precondition:** `git status --porcelain` must print nothing; otherwise stop and tell the user to commit or stash first — never auto-stash.
+
+Loop over the unchecked tasks in order, halting the line when a trigger fires:
+
+1. **Cross-repo:** the task prose puts the work in a separate repo → halt before spawning.
+2. Run Build payload and Verify return (below) for task N.
+3. **Failure:** STATUS not `complete`, or tests failing → halt; the box stays unchecked.
+4. **Escalation:** on `DEVIATIONS: interface-changing`, grep each named interface across the design specs of unstarted tasks only — any hit → halt; no hits → record it for the wrap-up and continue.
+5. Check the task's plan box, then commit only this task's changes: subject = the task title, body = `Task N of <plan-filename>`, no Co-Authored-By line. Never `cd` — the line assumes a single repo.
+
+**Halt report:** give the task number, title, and reason, ending with "Re-run `/dl:implement <slug> all` to resume." Checkboxes are the resume state — a re-run starts at the first unchecked box.
+
+When no unchecked tasks remain, do Gate once and wrap up the whole line: per-task results, commits, any recorded deviations.
 
 ## Build payload and spawn worker
 
@@ -48,7 +66,7 @@ Assemble the payload:
 - Paths of prior implementation notes for the slug, and the path of [implementation-note.md](implementation-note.md)
 - Mini-spec features: the `## Mini-Spec` section replaces the plan/design excerpts
 
-Spawn one general-purpose subagent whose prompt is the full text of [task-worker.md](task-worker.md) followed by the payload. Do not use a fork-type subagent — the worker must start from fresh context.
+Spawn one general-purpose subagent — never fork-type; the worker must start from fresh context — whose prompt is the full text of [task-worker.md](task-worker.md) followed by the payload.
 
 ## Verify return
 
@@ -56,11 +74,11 @@ The worker's final message ends with a fenced STATUS / FILES / TESTS / DEVIATION
 
 ## Gate
 
-Verify implementation note with `ls`. Update `.work/active/<slug>.md` with `stage: implement` and today's date.
+Verify the implementation note(s) with `ls`, then update `.work/active/<slug>.md` with `stage: implement` and today's date.
 
 ## Wrap up
 
-Summarize the worker's return: files created/modified, test results, deviations. Significant deviations → suggest `/design refine`; out-of-scope discoveries → suggest `/plan refine`. Suggest a git commit scoped to this task.
+Summarize the worker's return: files created/modified, test results, deviations. Significant deviations → suggest `/design refine`; out-of-scope discoveries → suggest `/plan refine`. Single-task mode only: suggest a git commit scoped to this task (all mode has already committed).
 
 ## Rules
 

--- a/plugins/dl/skills/implement/SKILL.md
+++ b/plugins/dl/skills/implement/SKILL.md
@@ -1,67 +1,70 @@
 ---
 name: implement
-description: Implements tasks from a plan and design, applying rules and saving implementation notes. Use when coding a planned feature or working through tasks one at a time.
+description: Implements tasks from a plan and design by delegating each task to a fresh-context worker subagent. Use when coding a planned feature or working through tasks one at a time.
 argument-hint: "[plan-slug] [task-number]"
-allowed-tools: Read Write Edit Bash(git:*)
+allowed-tools: Read Write Edit Bash(git:*) Agent
 ---
 
 Execute each section in order. Copy the checklist and check off items as you complete them. Do not proceed past a **Gate** until verified.
 
-**Artifact:** Write an implementation note to `.work/implementations/`. Verify with `ls` before wrapping up — even if the task is incomplete.
+**Artifact:** The worker writes an implementation note to `.work/implementations/`. Verify with `ls` before wrapping up — even if the task is incomplete.
 
-**Constraint:** You MUST implement only the selected task. Note out-of-scope discoveries in the implementation note rather than acting on them.
+**Constraint:** You are the foreman — you do not implement tasks yourself. A fresh-context worker subagent implements the selected task; you build its payload, verify its return, and own the plan checkboxes.
 
 ## Find the feature
 
 Check `.work/active/` for marker files. If exactly one exists and no $ARGUMENTS provided, auto-select that feature's slug. If multiple markers exist, list them, offer to archive any with `date` older than 30 days to `.work/archive/`, then ask. Arguments always override.
 
-Parse $ARGUMENTS as `<slug>` or `<slug> <task-N>`. If the marker has `stage: mini-spec`, read the brainstorm artifact's `## Mini-Spec` section as the spec — a single task, no plan or design required; skip task sync and picking. Otherwise find the plan in `.work/plans/` and matching design in `.work/designs/`. Missing design → print "No design found. Run /design first." and stop. No argument → list plan/design pairs; none: stop; one: confirm; many: ask to pick.
+Parse $ARGUMENTS as `<slug>` or `<slug> <task-N>`. If the marker has `stage: mini-spec`, read the brainstorm artifact's `## Mini-Spec` section as the spec — a single task (N = 1), no plan or design required; skip task picking. Otherwise find the plan in `.work/plans/` and matching design in `.work/designs/`. Missing design → print "No design found. Run /design first." and stop. No argument → list plan/design pairs; none: stop; one: confirm; many: ask to pick.
 
 ```
 Task Progress:
 - [ ] Find plan and design by slug
-- [ ] Read plan, design, and .mmd diagrams
-- [ ] Read completion state from the plan's checkboxes
+- [ ] Read plan and design; read completion state from the plan's checkboxes
 - [ ] Pick task (from args or ask)
-- [ ] Apply project rules from devloop/rules/
-- [ ] Read relevant files and run baseline tests
-- [ ] Implement against task spec
-- [ ] Re-run tests; check off the task in the plan
-- [ ] Write implementation note (see implementation-note.md)
+- [ ] Build the worker payload (task entry, design spec, rules, prior notes)
+- [ ] Spawn the worker; receive its structured return
+- [ ] Verify: note exists, STATUS complete, tests pass
+- [ ] Check off the task in the plan
 - [ ] Gate: verify note with ls; update active marker
-- [ ] Wrap up: summarize, note deviations, suggest commit
+- [ ] Wrap up: summarize worker return, note deviations, suggest commit
 ```
 
 ## Load
 
-Read plan and design in full. Read `.mmd` diagrams from `.work/designs/diagrams/` to understand proposed architecture. The plan's `- [ ]` checkboxes are the authoritative completion state — print the task list with status.
+Read plan and design in full. The plan's `- [ ]` checkboxes are the authoritative completion state — task numbers are positional. Print the task list with status.
 
 ## Pick task
 
 If $ARGUMENTS includes a task number, use it. Otherwise ask. Warn if dependencies are incomplete.
 
-## Apply rules
+## Build payload and spawn worker
 
-If the task spec has a `**Rules:**` line, apply the rules in `devloop/rules/` whose H1 titles match. Otherwise apply rules whose `keywords` match the task; rules without `keywords` always apply. Follow matched rules when modifying files under their scope. List applied rules in your response.
+Assemble the payload:
 
-## Execute
+- The plan task entry verbatim (title, description, Done when, Verified by) and its positional number N
+- The design's matching `### <task title>` spec section verbatim, plus paths of relevant `.work/designs/diagrams/*.mmd` files
+- Paths of rule docs in `devloop/rules/` whose H1 titles match the spec's `**Rules:**` line; no line → paths of rules whose `keywords` match the task (rules without `keywords` always apply)
+- Paths of prior implementation notes for the slug, and the path of [implementation-note.md](implementation-note.md)
+- Mini-spec features: the `## Mini-Spec` section replaces the plan/design excerpts
 
-Read all relevant files before editing. Run relevant tests to establish a baseline. Implement against the task spec (Goal, Interfaces, Acceptance criteria from design). Re-run tests — note failures or unexpected results. When fully done, check off the task's box in the plan file.
+Spawn one general-purpose subagent whose prompt is the full text of [task-worker.md](task-worker.md) followed by the payload. Do not use a fork-type subagent — the worker must start from fresh context.
 
-## Implementation note
+## Verify return
 
-Write the note per [implementation-note.md](implementation-note.md). Save to `.work/implementations/YYYY-MM-DD-<slug>-task-N.md`. In the Deviations section, list what design specified vs. what was done and why. This is read by `/review` to distinguish intentional deviations from violations.
+The worker's final message ends with a fenced STATUS / FILES / TESTS / DEVIATIONS / NOTE block. Verify the note file exists with `ls` — if missing, write a stub note from the structured return and treat the task as failed. Check off the task's plan checkbox only when STATUS is `complete` and tests pass. On `blocked`, present the worker's options to the user.
 
 ## Gate
 
-Verify implementation note with `ls`; write if missing. Update `.work/active/<slug>.md` with `stage: implement` and today's date.
+Verify implementation note with `ls`. Update `.work/active/<slug>.md` with `stage: implement` and today's date.
 
 ## Wrap up
 
-Summarize changes (files created/modified). Note deviations — suggest `/design refine` if significant. If out-of-scope work discovered, suggest `/plan refine`. Suggest a git commit scoped to this task.
+Summarize the worker's return: files created/modified, test results, deviations. Significant deviations → suggest `/design refine`; out-of-scope discoveries → suggest `/plan refine`. Suggest a git commit scoped to this task.
 
 ## Rules
 
 - Do not start without a design file (mini-spec features excepted).
-- The plan file's checkboxes are the authoritative progress state — check off completed tasks there.
-- Implement only the selected task; note out-of-scope discoveries in the implementation note.
+- You are the foreman: the worker implements and writes the note — never do either yourself (stub-on-missing-note excepted).
+- The plan file's checkboxes are the authoritative progress state — check off only verified completions.
+- Spawn workers with fresh context (general-purpose), never fork-type.

--- a/plugins/dl/skills/implement/SKILL.md
+++ b/plugins/dl/skills/implement/SKILL.md
@@ -40,7 +40,7 @@ If $ARGUMENTS includes a task number, use it; if it says `all`, follow All mode 
 
 ## All mode
 
-`all` runs every unchecked task in plan order — position = task number, no dependency graph. Mini-spec features have a single task, so `all` behaves like task 1.
+`all` runs every unchecked task in plan order — position = task number, no dependency graph. Mini-spec features have no plan checkboxes: treat `all` as a single-task run and skip the loop.
 
 **Precondition:** `git status --porcelain` must print nothing; otherwise stop and tell the user to commit or stash first — never auto-stash.
 
@@ -48,11 +48,11 @@ Loop over the unchecked tasks in order, halting the line when a trigger fires:
 
 1. **Cross-repo:** the task prose puts the work in a separate repo → halt before spawning.
 2. Run Build payload and Verify return (below) for task N.
-3. **Failure:** STATUS not `complete`, or tests failing → halt; the box stays unchecked.
+3. **Failure:** STATUS not `complete`, or tests failing → revert the partial work (`git reset --hard`, then delete untracked files the return's FILES lists — the implementation note preserves the failure story) and halt; the box stays unchecked.
 4. **Escalation:** on `DEVIATIONS: interface-changing`, grep each named interface across the design specs of unstarted tasks only — any hit → halt; no hits → record it for the wrap-up and continue.
 5. Check the task's plan box, then commit only this task's changes: subject = the task title, body = `Task N of <plan-filename>`, no Co-Authored-By line. Never `cd` — the line assumes a single repo.
 
-**Halt report:** give the task number, title, and reason, ending with "Re-run `/dl:implement <slug> all` to resume." Checkboxes are the resume state — a re-run starts at the first unchecked box.
+**Halt report:** give the task number, title, reason, and tree state (failure halts: "partial work reverted — see the implementation note"), ending with "Re-run `/dl:implement <slug> all` to resume." Checkboxes are the resume state — a re-run starts at the first unchecked box.
 
 **End of line:** When no unchecked tasks remain, do Gate once — updating the marker to `stage: implement` + today's date is your last write to `.work/` — then invoke forked `/dl:review <slug>`, whose own gate archives the marker: make no marker or `.work/` writes after invoking review. End the line with a single final response — per-task results, commits, recorded deviations, and the review's findings presented without acting on them (fixes are the user's call); halted lines and single-task runs stop at their normal wrap-ups and never auto-run review.
 
@@ -60,7 +60,8 @@ Loop over the unchecked tasks in order, halting the line when a trigger fires:
 
 Assemble the payload:
 
-- The plan task entry verbatim (title, description, Done when, Verified by) and its positional number N
+- The feature slug, task number N (positional), today's date, and the repo root path — the worker needs these for the note filename and absolute paths
+- The plan task entry verbatim (title, description, Done when, Verified by)
 - The design's matching `### <task title>` spec section verbatim, plus paths of relevant `.work/designs/diagrams/*.mmd` files
 - Paths of rule docs in `devloop/rules/` whose H1 titles match the spec's `**Rules:**` line; no line → paths of rules whose `keywords` match the task (rules without `keywords` always apply)
 - Paths of prior implementation notes for the slug, and the path of [implementation-note.md](implementation-note.md)
@@ -70,7 +71,7 @@ Spawn one general-purpose subagent — never fork-type; the worker must start fr
 
 ## Verify return
 
-The worker's final message ends with a fenced STATUS / FILES / TESTS / DEVIATIONS / NOTE block. Verify the note file exists with `ls` — if missing, write a stub note from the structured return and treat the task as failed. Check off the task's plan checkbox only when STATUS is `complete` and tests pass. On `blocked`, present the worker's options to the user.
+The worker's final message ends with a fenced STATUS / FILES / TESTS / DEVIATIONS / NOTE block. Verify the note file exists with `ls` — if missing, write a stub note from the structured return and treat the task as failed. Check off the task's plan checkbox only when STATUS is `complete` and TESTS reports passing or that none exist. On `blocked`, present the worker's options to the user.
 
 ## Gate
 
@@ -78,7 +79,7 @@ Verify the implementation note(s) with `ls`, then update `.work/active/<slug>.md
 
 ## Wrap up
 
-Summarize the worker's return: files created/modified, test results, deviations. Significant deviations → suggest `/design refine`; out-of-scope discoveries → suggest `/plan refine`. Single-task mode only: suggest a git commit scoped to this task (all mode has already committed).
+Summarize the worker's return: files created/modified, test results, deviations, and the rule docs the payload applied. Significant deviations → suggest `/design refine`; out-of-scope discoveries → suggest `/plan refine`. Single-task mode only: suggest a git commit scoped to this task (all mode has already committed).
 
 ## Rules
 

--- a/plugins/dl/skills/implement/SKILL.md
+++ b/plugins/dl/skills/implement/SKILL.md
@@ -48,11 +48,11 @@ Loop over the unchecked tasks in order, halting the line when a trigger fires:
 
 1. **Cross-repo:** the task prose puts the work in a separate repo → halt before spawning.
 2. Run Build payload and Verify return (below) for task N.
-3. **Failure:** STATUS not `complete`, or tests failing → revert the partial work (`git reset --hard`, then delete untracked files the return's FILES lists — the implementation note preserves the failure story) and halt; the box stays unchecked.
+3. **Failure:** STATUS not `complete`, or tests failing → revert the partial work (`git reset --hard`, then `git clean -f` the untracked FILES paths — excluding the NOTE path: the note preserves the failure story) and halt; the box stays unchecked.
 4. **Escalation:** on `DEVIATIONS: interface-changing`, grep each named interface across the design specs of unstarted tasks only — any hit → halt; no hits → record it for the wrap-up and continue.
 5. Check the task's plan box, then commit only this task's changes: subject = the task title, body = `Task N of <plan-filename>`, no Co-Authored-By line. Never `cd` — the line assumes a single repo.
 
-**Halt report:** give the task number, title, reason, and tree state (failure halts: "partial work reverted — see the implementation note"), ending with "Re-run `/dl:implement <slug> all` to resume." Checkboxes are the resume state — a re-run starts at the first unchecked box.
+**Halt report:** give the task number, title, reason, and tree state (failure halts: "partial work reverted — see the implementation note"; escalation halts: "work complete but uncommitted — commit or revert it before resuming"), ending with "Re-run `/dl:implement <slug> all` to resume." Checkboxes are the resume state — a re-run starts at the first unchecked box.
 
 **End of line:** When no unchecked tasks remain, do Gate once — updating the marker to `stage: implement` + today's date is your last write to `.work/` — then invoke forked `/dl:review <slug>`, whose own gate archives the marker: make no marker or `.work/` writes after invoking review. End the line with a single final response — per-task results, commits, recorded deviations, and the review's findings presented without acting on them (fixes are the user's call); halted lines and single-task runs stop at their normal wrap-ups and never auto-run review.
 
@@ -83,6 +83,5 @@ Summarize the worker's return: files created/modified, test results, deviations,
 
 ## Rules
 
-- Do not start without a design file (mini-spec features excepted).
 - You are the foreman: the worker implements and writes the note — never do either yourself (stub-on-missing-note excepted).
 - The plan file's checkboxes are the authoritative progress state — check off only verified completions.

--- a/plugins/dl/skills/implement/SKILL.md
+++ b/plugins/dl/skills/implement/SKILL.md
@@ -27,7 +27,7 @@ Task Progress:
 - [ ] Verify: note exists, STATUS complete, tests pass
 - [ ] Check off the task in the plan (all mode: commit, then next task or halt)
 - [ ] Gate: verify note with ls; update active marker
-- [ ] Wrap up: summarize worker return(s), note deviations, suggest commit
+- [ ] Wrap up: summarize worker return(s), note deviations, suggest commit (all mode: end with forked review's findings)
 ```
 
 ## Load
@@ -54,7 +54,7 @@ Loop over the unchecked tasks in order, halting the line when a trigger fires:
 
 **Halt report:** give the task number, title, and reason, ending with "Re-run `/dl:implement <slug> all` to resume." Checkboxes are the resume state — a re-run starts at the first unchecked box.
 
-When no unchecked tasks remain, do Gate once and wrap up the whole line: per-task results, commits, any recorded deviations.
+**End of line:** When no unchecked tasks remain, do Gate once — updating the marker to `stage: implement` + today's date is your last write to `.work/` — then invoke forked `/dl:review <slug>`, whose own gate archives the marker: make no marker or `.work/` writes after invoking review. End the line with a single final response — per-task results, commits, recorded deviations, and the review's findings presented without acting on them (fixes are the user's call); halted lines and single-task runs stop at their normal wrap-ups and never auto-run review.
 
 ## Build payload and spawn worker
 
@@ -85,4 +85,3 @@ Summarize the worker's return: files created/modified, test results, deviations.
 - Do not start without a design file (mini-spec features excepted).
 - You are the foreman: the worker implements and writes the note — never do either yourself (stub-on-missing-note excepted).
 - The plan file's checkboxes are the authoritative progress state — check off only verified completions.
-- Spawn workers with fresh context (general-purpose), never fork-type.

--- a/plugins/dl/skills/implement/task-worker.md
+++ b/plugins/dl/skills/implement/task-worker.md
@@ -1,0 +1,46 @@
+# Task worker
+
+You are a fresh-context implementation worker. The foreman sent this template plus a payload: one task entry, its design spec, and paths to rules, diagrams, prior implementation notes, and the implementation-note template. You implement exactly that one task.
+
+You run in an isolated context and cannot converse — if blocked on a decision, return `STATUS: blocked` with the options instead of asking.
+
+Copy this checklist and check off items as you complete them:
+
+```
+Worker Progress:
+- [ ] Read the payload: task entry, design spec, rule docs, diagrams, prior notes
+- [ ] Read all files relevant to the task before editing
+- [ ] Run relevant tests to establish a baseline
+- [ ] Implement against the task spec (Goal, Interfaces, Acceptance criteria)
+- [ ] Re-run tests; note failures or unexpected results
+- [ ] Write the implementation note
+- [ ] End with the structured return block
+```
+
+## Scope
+
+Implement only your assigned task. Note out-of-scope discoveries in the implementation note rather than acting on them. Follow the payload's rule docs when modifying files under their scope.
+
+## Prohibitions
+
+Never touch git (no commits, branches, stashes). Never edit the plan file's checkboxes. Never edit `.work/active/` markers. The foreman owns all three.
+
+## Implementation note
+
+Write the note per the implementation-note template in the payload. Save to `.work/implementations/YYYY-MM-DD-<slug>-task-N.md` even if the task is incomplete. In Deviations, list what the design specified vs. what was done and why — the reviewer reads this to distinguish intentional deviations from violations.
+
+## Structured return
+
+End your final message with exactly this fenced block:
+
+```
+STATUS: complete | failed | blocked
+FILES: <created/modified paths>
+TESTS: <pass/fail summary or "none exist">
+DEVIATIONS: none | in-scope: <summary> | interface-changing: <named interfaces + summary>
+NOTE: <implementation note path>
+```
+
+- `complete` requires acceptance criteria met and tests passing.
+- Declare `interface-changing` when you altered any interface, structure, or contract that other tasks may consume — name each one.
+- On `blocked`, state the decision needed and the options in your final message above the block.


### PR DESCRIPTION
## Summary

Stages 2+3 of the software-factory ladder. `/dl:implement` becomes a **foreman** that delegates each task to a **fresh-context worker subagent**, and gains an `all` mode that runs the whole plan as a sequential line.

- **Foreman/worker split** — the foreman builds a minimal per-task payload (plan entry, design task spec, rule paths, prior note paths) and spawns a general-purpose subagent from the new `task-worker.md` template. Deliberately not the `fork` agent type: forks inherit conversation history; fresh context per task is the point. The worker implements and writes the implementation note; the foreman verifies the structured return (`STATUS / FILES / TESTS / DEVIATIONS / NOTE`), owns plan checkboxes, git, and escalation.
- **`all` mode** — clean-tree precondition, sequential loop in plan order, one commit per task (subject = task title). Halt-the-line on: cross-repo task, worker failure (partial work auto-reverted, note preserved), or interface-changing deviation that unstarted task specs reference. Checkboxes are the resume state — re-running `all` resumes at the first unchecked box.
- **End of line** — a completed line auto-runs the forked `/dl:review` and surfaces its findings; review's gate archives the feature marker.
- **Docs + version** — README/workflow/artifacts re-describe both modes ("one task per worker"), version floor noted (Claude Code ≥2.1.172), 3.0.0 → 3.1.0.

Stacked on `feature/harness-simplification` (Stage 1: forked review/research, plan-checkbox tracking) — merge that first.

## Dogfooding

Tasks 2–4 of this feature were implemented *by* the machinery task 1 built: fresh-context workers with the foreman loop, per-task commits, and three rounds of the forked review (which caught two real bugs in the first fix commit — see `.work/reviews/`).

## Test plan

- [x] Worker contract dry-run: real subagent spawn against a scratch feature (checklist copied, note template-conformant, structured return well-formed, fresh context confirmed)
- [x] Task 4 acceptance greps (no stale "one task at a time" claims; 3.1.0 in both version files)
- [x] Three review rounds → clean verdict
- [ ] Live as-installed test: reinstall local plugin at 3.1.0, run a scratch line end-to-end (full run, induced failure → revert → halt → resume, dirty-tree stop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)