### PR TITLE
Self-heal .gitignore for .work/ before implement's clean-tree check

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "dl",
       "description": "Structured development workflow for Claude Code — brainstorm, research, plan, design, implement, review",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "source": "./plugins/dl"
     }
   ]

--- a/plugins/dl/.claude-plugin/plugin.json
+++ b/plugins/dl/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dl",
   "description": "Structured development workflow for Claude Code — brainstorm, research, plan, design, implement, review",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "author": {
     "name": "minusblindfold"
   },

--- a/plugins/dl/skills/implement/SKILL.md
+++ b/plugins/dl/skills/implement/SKILL.md
@@ -42,7 +42,7 @@ If $ARGUMENTS includes a task number, use it; if it says `all`, follow All mode 
 
 `all` runs every unchecked task in plan order — position = task number, no dependency graph. Mini-spec features have no plan checkboxes: treat `all` as a single-task run and skip the loop.
 
-**Precondition:** `git status --porcelain` must print nothing; otherwise stop and tell the user to commit or stash first — never auto-stash.
+**Precondition:** First ensure `.gitignore` ignores `.work/` — if no existing pattern already covers it, append a `.work/` line (creating the file if it doesn't exist) and commit that change alone (e.g. `Ignore devloop .work/ artifacts`), so the bootstrap edit never registers as dirt itself. Then `git status --porcelain` must print nothing; otherwise stop and tell the user to commit or stash first — never auto-stash.
 
 Loop over the unchecked tasks in order, halting the line when a trigger fires:
 


### PR DESCRIPTION
## Summary
- `.work/` artifacts from brainstorm/plan/design showed up as untracked files in companion repos that never gitignore them, tripping `/dl:implement <slug> all`'s clean-tree precondition on dirt the workflow itself created.
- The precondition now ensures `.gitignore` covers `.work/` first, committing that bootstrap edit on its own so it doesn't itself register as dirt, before checking `git status --porcelain`.
- Bumped plugin version 3.2.0 → 3.2.1 (bug fix, per versioning rules in CLAUDE.md).

## Test plan
- [ ] Live-test via `claude --plugin-dir .` in a fresh repo without `.work/` gitignored: run brainstorm → plan → design → `/dl:implement <slug> all` and confirm it no longer halts on `.work/` dirt
- [ ] Confirm the `.gitignore` bootstrap commit appears standalone, and only genuine uncommitted changes trigger the "commit or stash" halt