### PR TITLE
Harden all-mode against context growth; suggest compaction after review

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "dl",
       "description": "Structured development workflow for Claude Code — brainstorm, research, plan, design, implement, review",
-      "version": "3.2.1",
+      "version": "3.3.0",
       "source": "./plugins/dl"
     }
   ]

--- a/plugins/dl/.claude-plugin/plugin.json
+++ b/plugins/dl/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dl",
   "description": "Structured development workflow for Claude Code — brainstorm, research, plan, design, implement, review",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "author": {
     "name": "minusblindfold"
   },

--- a/plugins/dl/skills/implement/SKILL.md
+++ b/plugins/dl/skills/implement/SKILL.md
@@ -47,10 +47,11 @@ If $ARGUMENTS includes a task number, use it; if it says `all`, follow All mode 
 Loop over the unchecked tasks in order, halting the line when a trigger fires:
 
 1. **Cross-repo:** the task prose puts the work in a separate repo → halt before spawning.
-2. Run Build payload and Verify return (below) for task N.
-3. **Failure:** STATUS not `complete`, or tests failing → revert the partial work (`git reset --hard`, then `git clean -f` the untracked FILES paths — excluding the NOTE path: the note preserves the failure story) and halt; the box stays unchecked.
-4. **Escalation:** on `DEVIATIONS: interface-changing`, grep each named interface across the design specs of unstarted tasks only — any hit → halt; no hits → record it for the wrap-up and continue.
-5. Check the task's plan box, then commit only this task's changes: subject = the task title, body = `Task N of <plan-filename>`, no Co-Authored-By line. Never `cd` — the line assumes a single repo.
+2. Re-read the plan and design fresh from disk before building the payload — don't rely on the initial Load; this keeps state correct across a long run even if context has been compacted since.
+3. Run Build payload and Verify return (below) for task N.
+4. **Failure:** STATUS not `complete`, or tests failing → revert the partial work (`git reset --hard`, then `git clean -f` the untracked FILES paths — excluding the NOTE path: the note preserves the failure story) and halt; the box stays unchecked.
+5. **Escalation:** on `DEVIATIONS: interface-changing`, grep each named interface across the design specs of unstarted tasks only — any hit → halt; no hits → record it for the wrap-up and continue.
+6. Check the task's plan box, then commit only this task's changes: subject = the task title, body = `Task N of <plan-filename>`, no Co-Authored-By line. Never `cd` — the line assumes a single repo.
 
 **Halt report:** give the task number, title, reason, and tree state (failure halts: "partial work reverted — see the implementation note"; escalation halts: "work complete but uncommitted — commit or revert it before resuming"), ending with "Re-run `/dl:implement <slug> all` to resume." Checkboxes are the resume state — a re-run starts at the first unchecked box.
 

--- a/plugins/dl/skills/review/SKILL.md
+++ b/plugins/dl/skills/review/SKILL.md
@@ -81,7 +81,7 @@ Verify artifact with `ls`; write if missing. Update `.work/active/<slug>.md` wit
 
 ## Wrap up
 
-Summarize: rule violations, general findings, security findings. If findings exist, suggest addressing them. If clean, confirm. Suggest `/dl:review <slug>` again after fixes.
+Summarize: rule violations, general findings, security findings. If findings exist, suggest addressing them. If clean, confirm. Suggest `/dl:review <slug>` again after fixes. The marker is archived and the feature's state is fully captured in commits and `.work/` artifacts — suggest the user run `/compact` (or start a fresh session) before beginning the next feature.
 
 ## Rules
 


### PR DESCRIPTION
## Summary
- `/dl:implement <slug> all`'s foreman loop isn't forked (unlike research/review) and doesn't get a fresh context per task worker either — it accumulates plan/design text plus every task's payload/return/commit output turn over turn, which fills context faster on newer models. The loop now re-reads the plan and design fresh from disk each iteration instead of trusting whatever's still in context since the initial `Load`.
- Review's Gate always archives the active marker and completes the feature, whether standalone or chained from implement. Its wrap-up now suggests the user run `/compact` (or start a fresh session) before starting the next feature — nothing is lost since state is fully captured in commits and `.work/` artifacts.
- Bumped plugin version 3.2.1 → 3.3.0 (minor, changed skill behavior).

## Test plan
- [ ] Live-test via `claude --plugin-dir .`: run `/dl:implement <slug> all` on a multi-task plan and confirm the loop still tracks checkbox state correctly across tasks
- [ ] Run `/dl:review` to completion and confirm the wrap-up includes the compact/fresh-session suggestion